### PR TITLE
Fix reference to matchbrackets addon in test page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 <script src="node_modules/codemirror/addon/fold/brace-fold.js"></script>
 <script src="node_modules/codemirror/addon/edit/trailingspace.js"></script>
 <script src="node_modules/codemirror/addon/edit/matchtags.js"></script>
-<script src="../../codemirror/addon/edit/matchbrackets.js"></script>
+<script src="node_modules/codemirror/addon/edit/matchbrackets.js"></script>
 <script src="node_modules/codemirror/addon/edit/continuelist.js"></script>
 <script src="node_modules/codemirror/addon/edit/closetag.js"></script>
 <script src="node_modules/codemirror/addon/edit/closebrackets.js"></script>


### PR DESCRIPTION
Looks like this was mistakenly committed in 830e3df2de1951fd0c86ef306bf2bf2cb40901f6