### PR TITLE
Support tokenizing embedded languages in JS/TS tagged template literals

### DIFF
--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -2,7 +2,7 @@
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('codemirror'), require('codemirror-grammar-mode')) :
   typeof define === 'function' && define.amd ? define(['codemirror', 'codemirror-grammar-mode'], factory) :
   (factory(global.CodeMirror));
-}(this, (function (CodeMirror) { 'use strict';
+}(this, (function (CodeMirror$1) { 'use strict';
 
   var e = [/^(?:var|let|const)(?![a-zA-Z¡-￿_0-9_\$])/, /^while(?![a-zA-Z¡-￿_0-9_\$])/, /^with(?![a-zA-Z¡-￿_0-9_\$])/, /^do(?![a-zA-Z¡-￿_0-9_\$])/, /^debugger(?![a-zA-Z¡-￿_0-9_\$])/, /^if(?![a-zA-Z¡-￿_0-9_\$])/, /^function(?![a-zA-Z¡-￿_0-9_\$])/, /^for(?![a-zA-Z¡-￿_0-9_\$])/, /^default(?![a-zA-Z¡-￿_0-9_\$])/, /^case(?![a-zA-Z¡-￿_0-9_\$])/, /^return(?![a-zA-Z¡-￿_0-9_\$])/, /^throw(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:break|continue)(?![a-zA-Z¡-￿_0-9_\$])/, /^switch(?![a-zA-Z¡-￿_0-9_\$])/, /^try(?![a-zA-Z¡-￿_0-9_\$])/, /^class(?![a-zA-Z¡-￿_0-9_\$])/, /^export(?![a-zA-Z¡-￿_0-9_\$])/, /^import(?![a-zA-Z¡-￿_0-9_\$])/, [0, "async", /^(?![a-zA-Z¡-￿_0-9_\$])/, [5, 114]], [1, ";", /^(?=\})/, [7, "canInsertSemi"]], /^[a-zA-Z¡-￿__\$][a-zA-Z¡-￿_0-9_\$]*/, /^extends(?![a-zA-Z¡-￿_0-9_\$])/, /^from(?![a-zA-Z¡-￿_0-9_\$])/, /^else(?![a-zA-Z¡-￿_0-9_\$])/, /^catch(?![a-zA-Z¡-￿_0-9_\$])/, /^finally(?![a-zA-Z¡-￿_0-9_\$])/, /^as(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:true|false|null|undefined|NaN|Infinity)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:super|this)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:delete|typeof|yield|await|void)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:\.\.\.|\!|\+\+?|\-\-?)/, /^(?:0x[0-9a-fA-F_]+|0o[0-7_]+|0b[01_]+|(?:[0-9][0-9_]*(?:\.[0-9_]*)?|\.[0-9_]+)(?:[eE][\+\-]?[0-9_]+)?)/, /^\/(?![\/\*])(?:\\.|\[(?:(?!\]).)*\]|(?!\/).)+\/[gimyus]*/, /^(?:\+\+|\-\-)/, /^(?:\+|\-|\%|\*|\/(?![\/\*])|\>\>?\>?|\<\<?|\=\=?|\&\&?|\|\|?|\^|\!\=)\=?/, /^(?:in|instanceof)(?![a-zA-Z¡-￿_0-9_\$])/, /^[a-zA-Z¡-￿__\$][a-zA-Z¡-￿_0-9_\$]*(?= *\()/, [1, "\n", "\t", " "], /^new(?![a-zA-Z¡-￿_0-9_\$])/];
   var nodes = [
@@ -680,22 +680,22 @@
   function baseIndent(cx, config) {
     for (var startLine = cx.startLine;; cx = cx.parent) {
       if (cx.name == "CondExpr")
-        { return CodeMirror.countColumn(cx.startLine, cx.startPos + 1, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, cx.startPos + 1, config.tabSize) }
       if (statementish.indexOf(cx.name) > -1 && /(^\s*|[\(\{\[])$/.test(cx.startLine.slice(0, cx.startPos)))
-        { return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) }
       if (!cx.parent || cx.parent.startLine != startLine)
-        { return CodeMirror.countColumn(cx.startLine, null, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, null, config.tabSize) }
     }
   }
 
   function findIndent(cx, textAfter, config) {
     if (!cx) { return 0 }
-    if (cx.name == "string" || cx.name == "comment") { return CodeMirror.Pass }
+    if (cx.name == "string" || cx.name == "comment") { return CodeMirror$1.Pass }
 
     var brack = bracketed[cx.name];
     var closed = textAfter && textAfter.charAt(0) == brack;
     if (brack && config.align !== false && aligned(cx))
-      { return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + (closed ? 0 : 1) }
+      { return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) + (closed ? 0 : 1) }
 
     if (brack && blockish.indexOf(cx.name) > -1) {
       var parent = cx.parent;
@@ -724,7 +724,7 @@
     } else if (cx.name == "ArrowRest") {
       return base + config.indentUnit
     } else if (cx.name == "NewExpression" && cx.startLine.length > cx.startPos + 5) {
-      return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + 2 * config.indentUnit
+      return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) + 2 * config.indentUnit
     } else if (cx.name == "InitializerList") {
       return base + 2
     } else if (cx.name == "ThrowsClause" && !/throws\s*$/.test(cx.startLine.slice(cx.startPos))) {
@@ -738,7 +738,7 @@
     for (;; cx = cx.parent) {
       if (!cx) { return 0 }
       if (statementish.indexOf(cx.name) > -1 || (cx.parent && bracketed[cx.parent.name]))
-        { return CodeMirror.countColumn(cx.startLine, null, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, null, config.tabSize) }
     }
   }
 
@@ -748,7 +748,7 @@
       { return statementIndent(state.context, config) }
 
     if ((top == "doccomment.braced" || top == "doccomment.tagGroup") && !/^[@*]/.test(textAfter))
-      { return CodeMirror.countColumn(state.context.startLine, null, config.tabSize) + 2 * config.indentUnit }
+      { return CodeMirror$1.countColumn(state.context.startLine, null, config.tabSize) + 2 * config.indentUnit }
 
     return findIndent(state.contextAt(line, line.length - textAfter.length), textAfter, config)
   }
@@ -762,13 +762,389 @@
     return true
   }
 
+  /**
+   * @fileoverview Provides a class that facilitates tokenizing JavaScript tagged
+   * template string contents as a separate, embedded language.
+   *
+   * Consider code like:
+   *     html`<div>Hello ${'world'}</div>`
+   *
+   * For a good editing experience, the contents of that template string should
+   * be syntax highlighted as HTML.
+   *
+   * Doing this correctly in the limit is more difficult than it appears however,
+   * because arbitrary JS expressions are allowed inline, up to and including
+   * nesting of templates. This is even used in the real world. Consider:
+   *
+   * html`
+   *   <style>
+   *     ${css`
+   *       li {
+   *         color: green;
+   *       }
+   *     `}
+   *   </style>
+   *   <ul>
+   *     ${items.map(item => html`<li>${item}</li>`)}
+   *   </ul>
+   * `
+   */
+
+  /**
+   * Use within a containing tokenizer to defer tokenizing the contents of some
+   * JavaScript tagged template literals to other CodeMirror language modes.
+   *
+   * This tokenizer is intended to be used from a JavaScript tokenizer, or
+   * one very similar to JavaScript, like TypeScript. It assumes that tagged
+   * template literals are tagged with the style 'string-2'.
+   *
+   * This class maintains its own state. Its state needs to be stored as part
+   * of the containing tokenizer's state, and copied when it is copied. See
+   * startState and copyState.
+   *
+   * Design goals:
+   *   - Minimally interfere with containing tokenizer, and make minimal
+   *     assumptions about its behavior.
+   *   - Have no impact on tokenizing code that does not use tagged template
+   *     literals, or tagged template literals that do not correspond to other
+   *     languages
+   *   - Defer tokenizing the contents of template strings to embedded language
+   *     modes but begin, end, and interrupt template strings according to the
+   *     JavaScript grammar.
+   *   - Parse correctly even for deeply nested combinations of literals inside
+   *     of literals.
+   *
+   * Known limitations:
+   *   - Embedded tokenizers will see JavaScript string escape sequences
+   *     (like \`, \\, etc), though semantically they should see the unescaped
+   *     values. This can confuse embedded tokenizers, though that confusion
+   *     will not spread outside of the template string.
+   */
+  var TemplateTokenizer = function TemplateTokenizer(config) {
+    this.config = config;
+  };
+
+  /** @return {!State} */
+  TemplateTokenizer.prototype.startState = function startState () {
+    return new State();
+  };
+
+  /**
+   * @param {!State} state
+   * @return {!State}
+   */
+  TemplateTokenizer.prototype.copyState = function copyState (state) {
+    return state.copy();
+  };
+
+  /**
+   * If true, the containing tokenizer should defer to `interceptTokenizing`.
+   *
+   * @param {!State} state
+   */
+  TemplateTokenizer.prototype.shouldInterceptTokenizing = function shouldInterceptTokenizing (state) {
+    var templateState = state.currentTemplateState;
+    if (templateState !== undefined && templateState.mode !== null) {
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * Defer to the embedded language tokenizer, but interrupt it for inline
+   * exprssions and the end of the template literal.
+   *
+   * This MUST only be called if shouldInterceptTokenizing is true for the
+   * current state.
+   *
+   * shouldInterceptTokenizing is separated out into its own
+   * method, even though this method also tells the containing tokenizer
+   * when it should defer to the embedded language because this method returns
+   * an object, and we don't want to allocate an extra object for each token
+   * consumed.
+   *
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @return {{handled: boolean, state: string|null}} If handled is true,
+   *   then the TS/JS tokenizer should not do any tokenizing of its own,
+   *   and return state. If handled is false, then this method has consumed
+   *   no input, and instead the TS/JS tokenizer should consume input instead.
+   */
+  TemplateTokenizer.prototype.interceptTokenizing = function interceptTokenizing (stream, state) {
+    // Check for an inline expression in the template literal.
+    if (stream.match('${')) {
+      stream.backUp(2);
+      if (!this.isEscaped(stream, stream.pos - 2)) {
+        // Hand things back to the normal tokenizer.
+        return {handled: false};
+      }
+    }
+    // Check for end of the template literal.
+    if (stream.peek() === '`' && !this.isEscaped(stream, stream.pos)) {
+      // Hand things back to the normal tokenizer.
+      return {handled: false};
+    }
+    // Important note for the above two early exit checks. We must first check
+    // for the end characters, then check to see if they were escaped.
+    // That avoids doing exponential work in the case where there's a long
+    // sequence of backslashes that the embedded tokenizer consumes character
+    // by character.
+
+    var ref = state.currentTemplateState;
+      var mode = ref.mode;
+      var innerState = ref.state;
+    var style = mode.token(stream, innerState);
+    this.backupIfEmbeddedTokenizerOvershot(stream);
+    return {handled: true, style: style};
+  };
+
+  /**
+   * Called after the containing tokenizer has consumed a token, but before
+   * that consumption is finalized.
+   *
+   * We keep track of entering and exiting template literals and inline
+   * expressions in template literals. In some cases, we reduce the
+   * amount of text consumed by the containing tokenizer, so that an embedded
+   * language has the opportunity to tokenize the contents of a template
+   * string that it controls.
+   *
+   * @param {string|null} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   */
+  TemplateTokenizer.prototype.trackState = function trackState (style, stream, state) {
+    if (!style) {
+      return;
+    }
+    var templateState = state.currentTemplateState;
+    if (!templateState || templateState.kind === 'inline-expression') {
+      this.trackStateNotInTemplate(style, stream, state, templateState);
+    } else {
+      this.trackStateInTemplate(style, stream, state, templateState);
+    }
+    if (style === 'variable') {
+      state.previousVariable = stream.current();
+    } else {
+      state.previousVariable = null;
+    }
+  };
+
+  /**
+   * Maintain state.templateStack while not directly inside of a template
+   * literal.
+   *
+   * We could be inside of an inline expression in a template literal however.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {?TemplateState} templateState
+   */
+  TemplateTokenizer.prototype.trackStateNotInTemplate = function trackStateNotInTemplate (style, stream, state, templateState) {
+    // Has the inline expression represented by embeddedMode just ended?
+    if (templateState && style === 'string-2' &&
+        stream.current().startsWith('}')) {
+      state.templateStack.pop();
+      // The containing tokenizer should only consume the } at this point.
+      stream.backUp(stream.current().length - 1);
+      return;
+    }
+    // Are we starting a new template?
+    if (style === 'string-2' &&
+      stream.current().startsWith('`')) {
+      var mode = this.getModeForTemplateTag(state.previousVariable);
+      var kind = 'template';
+      if (mode) {
+        // Nothing except the opening ` should be consumed.
+        stream.backUp(stream.current().length - 1);
+        state.templateStack.push(new TemplateState(
+          kind,
+          mode,
+          CodeMirror.startState(mode)
+        ));
+      } else {
+        state.templateStack.push(new TemplateState(kind, null, null));
+      }
+    }
+  };
+
+  /**
+   * Maintain state.templateStack while in the contents of a template literal.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {!TemplateState} templateState
+   */
+  TemplateTokenizer.prototype.trackStateInTemplate = function trackStateInTemplate (style, stream, state, templateState) {
+    // Is the current template ending?
+    if (style === 'string-2' && stream.current().endsWith('`') &&
+        !this.isEscaped(stream.pos - 1)) {
+      state.templateStack.pop();
+      return;
+    }
+
+    // Are we starting a new inline expression?
+    if (style === 'string-2' && stream.current().endsWith('${') &&
+        !this.isEscaped(stream.pos - 2)) {
+      state.templateStack.push(
+          new TemplateState('inline-expression', null, null));
+      return;
+    }
+  };
+
+  /**
+   * Inside of an inline template, we've let the embedded language tokenizer
+   * consume a token. However, it can't be allowed to consume text that actually
+   * indicates the end of that section of template literal string. If it has
+   * back up to right beforehand.
+   *
+   * @private
+   * @param {!Stream} stream
+   */
+  TemplateTokenizer.prototype.backupIfEmbeddedTokenizerOvershot = function backupIfEmbeddedTokenizerOvershot (stream) {
+    var cur = stream.current();
+    var searchFrom = 0;
+    while(true) {
+      var closingIdx = cur.slice(searchFrom).search(/`|\$\{/);
+      if (closingIdx === -1) {
+        // No template boundary found in the token.
+        return;
+      }
+      closingIdx = closingIdx + searchFrom;
+      var amountToBackUp = cur.length - closingIdx;
+      var locationOfEarlyExit = stream.pos - amountToBackUp;
+      var escaped = this.isEscaped(stream, locationOfEarlyExit);
+      if (!escaped) {
+        // Found a template boundary. Must not consume it.
+        stream.backUp(cur.length - closingIdx);
+        return;
+      }
+      // Found a potential template boundary, but it turns out it
+      // was escaped with backslashes, so we need to keep looking beyond it.
+      searchFrom = closingIdx + 1;
+    }
+  };
+
+  /**
+   * Walks backwards from the given position in the stream looking for
+   * backslashes. Returns true if there are an odd number, and so the given
+   * position is string-escaped, and false if there are an even number.
+   *
+   * @private
+   * @param {!Stream} stream
+   * @param {number} start
+   */
+  TemplateTokenizer.prototype.isEscaped = function isEscaped (stream, start) {
+    var escaped = false;
+    var idx = start;
+    while(idx > 0) {
+      if (stream.string[idx - 1] !== '\\') {
+        break;
+      }
+      escaped = !escaped;
+      idx--;
+    }
+    return escaped;
+  };
+
+  /**
+   * @private
+   * @param {string|null} templateTag
+   */
+  TemplateTokenizer.prototype.getModeForTemplateTag = function getModeForTemplateTag (templateTag) {
+    if (!templateTag) {
+      return null;
+    }
+    // There are likely more customizations that would be nice here.
+    // Would be a good place for configuration if so.
+    if (templateTag === 'htm') {
+      templateTag = 'html';
+    }
+    var modeSpecs = [("google-" + templateTag), ("" + templateTag)];
+    // Note: the google-modules build pipeline does not currently support
+    // for/of.
+    for (var i = 0; i < modeSpecs.length; i++) {
+      var mode = CodeMirror.getMode(this.config, modeSpecs[i]);
+      if (mode && mode.name !== 'null') {
+        return mode;
+      }
+    }
+    return null;
+  };
+
+  var State = function State(templateStack, previousVariable) {
+    if ( templateStack === void 0 ) templateStack = [];
+    if ( previousVariable === void 0 ) previousVariable = null;
+
+    /**
+     * A stack to keep track of the nesting of templates and inline expressions.
+     *
+     * Whenever we enter a template, we push a TemplateState with kind
+     * 'template' on the stack. Whenever, inside of a template, we enter
+     * an inline expression i.e. ${}, we push a TemplateState with kind
+     * 'inline-expression' on the stack. Likewise, as we leave templates and
+     * inline expressions we pop them off.
+     *
+     * A template that is being tokenized with an embedded CodeMirror mode will
+     * have a `mode` and its `state` on its associated TemplateState.
+     *
+     * @type {Array<!TemplateState>}
+     */
+    this.templateStack = templateStack;
+    /**
+     * Used to figure out the tag name of tagged template literals, to
+     * infer the inline language.
+     *
+     * @type {null|string}
+     */
+    this.previousVariable = previousVariable;
+  };
+
+  var prototypeAccessors = { currentTemplateState: { configurable: true } };
+
+  State.prototype.copy = function copy () {
+    return new State(
+        this.templateStack.map(function (t) { return t.copy(); }), this.previousVariable);
+  };
+
+  /** @return {!TemplateState | undefined} */
+  prototypeAccessors.currentTemplateState.get = function () {
+    return this.templateStack[this.templateStack.length - 1];
+  };
+
+  Object.defineProperties( State.prototype, prototypeAccessors );
+
+  var TemplateState = function TemplateState(kind, mode, state) {
+    /** @type {string} Either 'template' or 'inline-expression' */
+    this.kind = kind;
+    /**
+     * @type {?CodeMirror.Mode} If defined, the mode to tokenize
+     * the current template with. kind must be 'template' if this is defined.
+     */
+    this.mode = mode;
+    /** @type {?} The state object for this.mode. */
+    this.state = state;
+  };
+
+  TemplateState.prototype.copy = function copy () {
+    if (!this.mode) {
+      return new TemplateState(this.kind, null, null);
+    }
+    return new TemplateState(
+        this.kind, this.mode, CodeMirror.copyState(this.mode, this.state))
+  };
+
   var scopes = ["Block", "FunctionDef", "ArrowFunc", "ForStatement"];
 
-  var JSMode = (function (superclass) {
+  var JSMode = /*@__PURE__*/(function (superclass) {
     function JSMode(conf, modeConf) {
       superclass.call(this, grammar, {
         predicates: {canInsertSemi: modeConf.requireSemicolons === false ? canInsertSemi : function () { return false; }}
       });
+      this.embeddedParser = new TemplateTokenizer(conf);
       this.indentConf = {doubleIndentBrackets: ">)", dontCloseBrackets: ")", tabSize: conf.tabSize, indentUnit: conf.indentUnit};
     }
 
@@ -776,8 +1152,34 @@
     JSMode.prototype = Object.create( superclass && superclass.prototype );
     JSMode.prototype.constructor = JSMode;
 
+    JSMode.prototype.startState = function startState () {
+      var state = superclass.prototype.startState.call(this);
+      state.embeddedParserState = this.embeddedParser.startState();
+      return state;
+    };
+
+    JSMode.prototype.copyState = function copyState (state) {
+      var copy = superclass.prototype.copyState.call(this, state);
+      copy.embeddedParserState =
+          this.embeddedParser.copyState(state.embeddedParserState);
+      return copy;
+    };
+
     JSMode.prototype.token = function token$$1 (stream, state) {
-      return markLocals(superclass.prototype.token.call(this, stream, state), scopes, stream, state)
+      var embeddedParserState = state.embeddedParserState;
+      if (this.embeddedParser.shouldInterceptTokenizing(embeddedParserState)) {
+        var ref = this.embeddedParser.interceptTokenizing(
+            stream, embeddedParserState);
+        var handled = ref.handled;
+        var style$1 = ref.style;
+        if (handled) {
+          return style$1;
+        }
+      }
+      var style = superclass.prototype.token.call(this, stream, state);
+      this.embeddedParser.trackState(
+          style, stream, embeddedParserState);
+      return markLocals(style, scopes, stream, state)
     };
 
     JSMode.prototype.indent = function indent$1 (state, textAfter, line) {
@@ -786,7 +1188,7 @@
     };
 
     return JSMode;
-  }(CodeMirror.GrammarMode));
+  }(CodeMirror$1.GrammarMode));
 
   var meta = {
     electricInput: /^\s*(?:case .*?:|default:|\{|\})$/,
@@ -799,8 +1201,8 @@
   };
   for (var prop in meta) { JSMode.prototype[prop] = meta[prop]; }
 
-  CodeMirror.registerHelper("wordChars", "google-javascript", /[\w$]/);
+  CodeMirror$1.registerHelper("wordChars", "google-javascript", /[\w$]/);
 
-  CodeMirror.defineMode("google-javascript", function (conf, modeConf) { return new JSMode(conf, modeConf); });
+  CodeMirror$1.defineMode("google-javascript", function (conf, modeConf) { return new JSMode(conf, modeConf); });
 
 })));

--- a/dist/typescript.js
+++ b/dist/typescript.js
@@ -2,7 +2,7 @@
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('codemirror'), require('codemirror-grammar-mode')) :
   typeof define === 'function' && define.amd ? define(['codemirror', 'codemirror-grammar-mode'], factory) :
   (factory(global.CodeMirror));
-}(this, (function (CodeMirror) { 'use strict';
+}(this, (function (CodeMirror$1) { 'use strict';
 
   var e = [/^(?:var|let|const)(?![a-zA-Z¡-￿_0-9_\$])/, /^while(?![a-zA-Z¡-￿_0-9_\$])/, /^with(?![a-zA-Z¡-￿_0-9_\$])/, /^do(?![a-zA-Z¡-￿_0-9_\$])/, /^debugger(?![a-zA-Z¡-￿_0-9_\$])/, /^if(?![a-zA-Z¡-￿_0-9_\$])/, /^function(?![a-zA-Z¡-￿_0-9_\$])/, /^for(?![a-zA-Z¡-￿_0-9_\$])/, /^default(?![a-zA-Z¡-￿_0-9_\$])/, /^case(?![a-zA-Z¡-￿_0-9_\$])/, /^return(?![a-zA-Z¡-￿_0-9_\$])/, /^throw(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:break|continue)(?![a-zA-Z¡-￿_0-9_\$])/, /^switch(?![a-zA-Z¡-￿_0-9_\$])/, /^try(?![a-zA-Z¡-￿_0-9_\$])/, /^class(?![a-zA-Z¡-￿_0-9_\$])/, /^export(?![a-zA-Z¡-￿_0-9_\$])/, /^import(?![a-zA-Z¡-￿_0-9_\$])/, [0, "async", /^(?![a-zA-Z¡-￿_0-9_\$])/, [5, 139]], /^[a-zA-Z¡-￿__\$][a-zA-Z¡-￿_0-9_\$]*/, /^extends(?![a-zA-Z¡-￿_0-9_\$])/, /^enum(?![a-zA-Z¡-￿_0-9_\$])/, [1, ";", /^(?=\})/, [7, "canInsertSemi"]], /^from(?![a-zA-Z¡-￿_0-9_\$])/, [1, "\n", "\t", " "], /^[a-zA-Z¡-￿__\$]/, /^const(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:true|false|null|undefined|NaN|Infinity)(?![a-zA-Z¡-￿_0-9_\$])/, /^new(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:0x[0-9a-fA-F_]+|0o[0-7_]+|0b[01_]+|(?:[0-9][0-9_]*(?:\.[0-9_]*)?|\.[0-9_]+)(?:[eE][\+\-]?[0-9_]+)?)/, /^else(?![a-zA-Z¡-￿_0-9_\$])/, /^catch(?![a-zA-Z¡-￿_0-9_\$])/, /^finally(?![a-zA-Z¡-￿_0-9_\$])/, /^as(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:super|this)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:delete|typeof|yield|await|void)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:\.\.\.|\!|\+\+?|\-\-?)/, /^\/(?![\/\*])(?:\\.|\[(?:(?!\]).)*\]|(?!\/).)+\/[gimyus]*/, [0, /^[a-zA-Z¡-￿__\$]/, /^[a-zA-Z¡-￿_0-9_\$]*/, [5, 493]], /^(?:\+\+|\-\-)/, /^(?:\+|\-|\%|\*|\/(?![\/\*])|\>\>?\>?|\<\<?|\=\=?|\&\&?|\|\|?|\^|\!\=)\=?/, /^(?:in|instanceof)(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:public|private|protected|readonly|abstract|static)(?![a-zA-Z¡-￿_0-9_\$])/, [0, /^[a-zA-Z¡-￿__\$]/, /^[a-zA-Z¡-￿_0-9_\$]*/, [5, 518]], /^is(?![a-zA-Z¡-￿_0-9_\$])/, /^(?:\.\.\.)?/, /^(?:get|set|async)(?![a-zA-Z¡-￿_0-9_\$])(?! *[\,\}\:\(\<])/];
   var nodes = [
@@ -1091,22 +1091,22 @@
   function baseIndent(cx, config) {
     for (var startLine = cx.startLine;; cx = cx.parent) {
       if (cx.name == "CondExpr")
-        { return CodeMirror.countColumn(cx.startLine, cx.startPos + 1, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, cx.startPos + 1, config.tabSize) }
       if (statementish.indexOf(cx.name) > -1 && /(^\s*|[\(\{\[])$/.test(cx.startLine.slice(0, cx.startPos)))
-        { return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) }
       if (!cx.parent || cx.parent.startLine != startLine)
-        { return CodeMirror.countColumn(cx.startLine, null, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, null, config.tabSize) }
     }
   }
 
   function findIndent(cx, textAfter, config) {
     if (!cx) { return 0 }
-    if (cx.name == "string" || cx.name == "comment") { return CodeMirror.Pass }
+    if (cx.name == "string" || cx.name == "comment") { return CodeMirror$1.Pass }
 
     var brack = bracketed[cx.name];
     var closed = textAfter && textAfter.charAt(0) == brack;
     if (brack && config.align !== false && aligned(cx))
-      { return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + (closed ? 0 : 1) }
+      { return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) + (closed ? 0 : 1) }
 
     if (brack && blockish.indexOf(cx.name) > -1) {
       var parent = cx.parent;
@@ -1135,7 +1135,7 @@
     } else if (cx.name == "ArrowRest") {
       return base + config.indentUnit
     } else if (cx.name == "NewExpression" && cx.startLine.length > cx.startPos + 5) {
-      return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + 2 * config.indentUnit
+      return CodeMirror$1.countColumn(cx.startLine, cx.startPos, config.tabSize) + 2 * config.indentUnit
     } else if (cx.name == "InitializerList") {
       return base + 2
     } else if (cx.name == "ThrowsClause" && !/throws\s*$/.test(cx.startLine.slice(cx.startPos))) {
@@ -1149,7 +1149,7 @@
     for (;; cx = cx.parent) {
       if (!cx) { return 0 }
       if (statementish.indexOf(cx.name) > -1 || (cx.parent && bracketed[cx.parent.name]))
-        { return CodeMirror.countColumn(cx.startLine, null, config.tabSize) }
+        { return CodeMirror$1.countColumn(cx.startLine, null, config.tabSize) }
     }
   }
 
@@ -1159,7 +1159,7 @@
       { return statementIndent(state.context, config) }
 
     if ((top == "doccomment.braced" || top == "doccomment.tagGroup") && !/^[@*]/.test(textAfter))
-      { return CodeMirror.countColumn(state.context.startLine, null, config.tabSize) + 2 * config.indentUnit }
+      { return CodeMirror$1.countColumn(state.context.startLine, null, config.tabSize) + 2 * config.indentUnit }
 
     return findIndent(state.contextAt(line, line.length - textAfter.length), textAfter, config)
   }
@@ -1173,13 +1173,390 @@
     return true
   }
 
+  /**
+   * @fileoverview Provides a class that facilitates tokenizing JavaScript tagged
+   * template string contents as a separate, embedded language.
+   *
+   * Consider code like:
+   *     html`<div>Hello ${'world'}</div>`
+   *
+   * For a good editing experience, the contents of that template string should
+   * be syntax highlighted as HTML.
+   *
+   * Doing this correctly in the limit is more difficult than it appears however,
+   * because arbitrary JS expressions are allowed inline, up to and including
+   * nesting of templates. This is even used in the real world. Consider:
+   *
+   * html`
+   *   <style>
+   *     ${css`
+   *       li {
+   *         color: green;
+   *       }
+   *     `}
+   *   </style>
+   *   <ul>
+   *     ${items.map(item => html`<li>${item}</li>`)}
+   *   </ul>
+   * `
+   */
+
+  /**
+   * Use within a containing tokenizer to defer tokenizing the contents of some
+   * JavaScript tagged template literals to other CodeMirror language modes.
+   *
+   * This tokenizer is intended to be used from a JavaScript tokenizer, or
+   * one very similar to JavaScript, like TypeScript. It assumes that tagged
+   * template literals are tagged with the style 'string-2'.
+   *
+   * This class maintains its own state. Its state needs to be stored as part
+   * of the containing tokenizer's state, and copied when it is copied. See
+   * startState and copyState.
+   *
+   * Design goals:
+   *   - Minimally interfere with containing tokenizer, and make minimal
+   *     assumptions about its behavior.
+   *   - Have no impact on tokenizing code that does not use tagged template
+   *     literals, or tagged template literals that do not correspond to other
+   *     languages
+   *   - Defer tokenizing the contents of template strings to embedded language
+   *     modes but begin, end, and interrupt template strings according to the
+   *     JavaScript grammar.
+   *   - Parse correctly even for deeply nested combinations of literals inside
+   *     of literals.
+   *
+   * Known limitations:
+   *   - Embedded tokenizers will see JavaScript string escape sequences
+   *     (like \`, \\, etc), though semantically they should see the unescaped
+   *     values. This can confuse embedded tokenizers, though that confusion
+   *     will not spread outside of the template string.
+   */
+  var TemplateTokenizer = function TemplateTokenizer(config) {
+    this.config = config;
+  };
+
+  /** @return {!State} */
+  TemplateTokenizer.prototype.startState = function startState () {
+    return new State();
+  };
+
+  /**
+   * @param {!State} state
+   * @return {!State}
+   */
+  TemplateTokenizer.prototype.copyState = function copyState (state) {
+    return state.copy();
+  };
+
+  /**
+   * If true, the containing tokenizer should defer to `interceptTokenizing`.
+   *
+   * @param {!State} state
+   */
+  TemplateTokenizer.prototype.shouldInterceptTokenizing = function shouldInterceptTokenizing (state) {
+    var templateState = state.currentTemplateState;
+    if (templateState !== undefined && templateState.mode !== null) {
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * Defer to the embedded language tokenizer, but interrupt it for inline
+   * exprssions and the end of the template literal.
+   *
+   * This MUST only be called if shouldInterceptTokenizing is true for the
+   * current state.
+   *
+   * shouldInterceptTokenizing is separated out into its own
+   * method, even though this method also tells the containing tokenizer
+   * when it should defer to the embedded language because this method returns
+   * an object, and we don't want to allocate an extra object for each token
+   * consumed.
+   *
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @return {{handled: boolean, state: string|null}} If handled is true,
+   *   then the TS/JS tokenizer should not do any tokenizing of its own,
+   *   and return state. If handled is false, then this method has consumed
+   *   no input, and instead the TS/JS tokenizer should consume input instead.
+   */
+  TemplateTokenizer.prototype.interceptTokenizing = function interceptTokenizing (stream, state) {
+    // Check for an inline expression in the template literal.
+    if (stream.match('${')) {
+      stream.backUp(2);
+      if (!this.isEscaped(stream, stream.pos - 2)) {
+        // Hand things back to the normal tokenizer.
+        return {handled: false};
+      }
+    }
+    // Check for end of the template literal.
+    if (stream.peek() === '`' && !this.isEscaped(stream, stream.pos)) {
+      // Hand things back to the normal tokenizer.
+      return {handled: false};
+    }
+    // Important note for the above two early exit checks. We must first check
+    // for the end characters, then check to see if they were escaped.
+    // That avoids doing exponential work in the case where there's a long
+    // sequence of backslashes that the embedded tokenizer consumes character
+    // by character.
+
+    var ref = state.currentTemplateState;
+      var mode = ref.mode;
+      var innerState = ref.state;
+    var style = mode.token(stream, innerState);
+    this.backupIfEmbeddedTokenizerOvershot(stream);
+    return {handled: true, style: style};
+  };
+
+  /**
+   * Called after the containing tokenizer has consumed a token, but before
+   * that consumption is finalized.
+   *
+   * We keep track of entering and exiting template literals and inline
+   * expressions in template literals. In some cases, we reduce the
+   * amount of text consumed by the containing tokenizer, so that an embedded
+   * language has the opportunity to tokenize the contents of a template
+   * string that it controls.
+   *
+   * @param {string|null} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   */
+  TemplateTokenizer.prototype.trackState = function trackState (style, stream, state) {
+    if (!style) {
+      return;
+    }
+    var templateState = state.currentTemplateState;
+    if (!templateState || templateState.kind === 'inline-expression') {
+      this.trackStateNotInTemplate(style, stream, state, templateState);
+    } else {
+      this.trackStateInTemplate(style, stream, state, templateState);
+    }
+    if (style === 'variable') {
+      state.previousVariable = stream.current();
+    } else {
+      state.previousVariable = null;
+    }
+  };
+
+  /**
+   * Maintain state.templateStack while not directly inside of a template
+   * literal.
+   *
+   * We could be inside of an inline expression in a template literal however.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {?TemplateState} templateState
+   */
+  TemplateTokenizer.prototype.trackStateNotInTemplate = function trackStateNotInTemplate (style, stream, state, templateState) {
+    // Has the inline expression represented by embeddedMode just ended?
+    if (templateState && style === 'string-2' &&
+        stream.current().startsWith('}')) {
+      state.templateStack.pop();
+      // The containing tokenizer should only consume the } at this point.
+      stream.backUp(stream.current().length - 1);
+      return;
+    }
+    // Are we starting a new template?
+    if (style === 'string-2' &&
+      stream.current().startsWith('`')) {
+      var mode = this.getModeForTemplateTag(state.previousVariable);
+      var kind = 'template';
+      if (mode) {
+        // Nothing except the opening ` should be consumed.
+        stream.backUp(stream.current().length - 1);
+        state.templateStack.push(new TemplateState(
+          kind,
+          mode,
+          CodeMirror.startState(mode)
+        ));
+      } else {
+        state.templateStack.push(new TemplateState(kind, null, null));
+      }
+    }
+  };
+
+  /**
+   * Maintain state.templateStack while in the contents of a template literal.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {!TemplateState} templateState
+   */
+  TemplateTokenizer.prototype.trackStateInTemplate = function trackStateInTemplate (style, stream, state, templateState) {
+    // Is the current template ending?
+    if (style === 'string-2' && stream.current().endsWith('`') &&
+        !this.isEscaped(stream.pos - 1)) {
+      state.templateStack.pop();
+      return;
+    }
+
+    // Are we starting a new inline expression?
+    if (style === 'string-2' && stream.current().endsWith('${') &&
+        !this.isEscaped(stream.pos - 2)) {
+      state.templateStack.push(
+          new TemplateState('inline-expression', null, null));
+      return;
+    }
+  };
+
+  /**
+   * Inside of an inline template, we've let the embedded language tokenizer
+   * consume a token. However, it can't be allowed to consume text that actually
+   * indicates the end of that section of template literal string. If it has
+   * back up to right beforehand.
+   *
+   * @private
+   * @param {!Stream} stream
+   */
+  TemplateTokenizer.prototype.backupIfEmbeddedTokenizerOvershot = function backupIfEmbeddedTokenizerOvershot (stream) {
+    var cur = stream.current();
+    var searchFrom = 0;
+    while(true) {
+      var closingIdx = cur.slice(searchFrom).search(/`|\$\{/);
+      if (closingIdx === -1) {
+        // No template boundary found in the token.
+        return;
+      }
+      closingIdx = closingIdx + searchFrom;
+      var amountToBackUp = cur.length - closingIdx;
+      var locationOfEarlyExit = stream.pos - amountToBackUp;
+      var escaped = this.isEscaped(stream, locationOfEarlyExit);
+      if (!escaped) {
+        // Found a template boundary. Must not consume it.
+        stream.backUp(cur.length - closingIdx);
+        return;
+      }
+      // Found a potential template boundary, but it turns out it
+      // was escaped with backslashes, so we need to keep looking beyond it.
+      searchFrom = closingIdx + 1;
+    }
+  };
+
+  /**
+   * Walks backwards from the given position in the stream looking for
+   * backslashes. Returns true if there are an odd number, and so the given
+   * position is string-escaped, and false if there are an even number.
+   *
+   * @private
+   * @param {!Stream} stream
+   * @param {number} start
+   */
+  TemplateTokenizer.prototype.isEscaped = function isEscaped (stream, start) {
+    var escaped = false;
+    var idx = start;
+    while(idx > 0) {
+      if (stream.string[idx - 1] !== '\\') {
+        break;
+      }
+      debugger;
+      escaped = !escaped;
+      idx--;
+    }
+    return escaped;
+  };
+
+  /**
+   * @private
+   * @param {string|null} templateTag
+   */
+  TemplateTokenizer.prototype.getModeForTemplateTag = function getModeForTemplateTag (templateTag) {
+    if (!templateTag) {
+      return null;
+    }
+    // There are likely more customizations that would be nice here.
+    // Would be a good place for configuration if so.
+    if (templateTag === 'htm') {
+      templateTag = 'html';
+    }
+    var modeSpecs = [("google-" + templateTag), ("" + templateTag)];
+    // Note: the google-modules build pipeline does not currently support
+    // for/of.
+    for (var i = 0; i < modeSpecs.length; i++) {
+      var mode = CodeMirror.getMode(this.config, modeSpecs[i]);
+      if (mode && mode.name !== 'null') {
+        return mode;
+      }
+    }
+    return null;
+  };
+
+  var State = function State(templateStack, previousVariable) {
+    if ( templateStack === void 0 ) templateStack = [];
+    if ( previousVariable === void 0 ) previousVariable = null;
+
+    /**
+     * A stack to keep track of the nesting of templates and inline expressions.
+     *
+     * Whenever we enter a template, we push a TemplateState with kind
+     * 'template' on the stack. Whenever, inside of a template, we enter
+     * an inline expression i.e. ${}, we push a TemplateState with kind
+     * 'inline-expression' on the stack. Likewise, as we leave templates and
+     * inline expressions we pop them off.
+     *
+     * A template that is being tokenized with an embedded CodeMirror mode will
+     * have a `mode` and its `state` on its associated TemplateState.
+     *
+     * @type {Array<!TemplateState>}
+     */
+    this.templateStack = templateStack;
+    /**
+     * Used to figure out the tag name of tagged template literals, to
+     * infer the inline language.
+     *
+     * @type {null|string}
+     */
+    this.previousVariable = previousVariable;
+  };
+
+  var prototypeAccessors = { currentTemplateState: { configurable: true } };
+
+  State.prototype.copy = function copy () {
+    return new State(
+        this.templateStack.map(function (t) { return t.copy(); }), this.previousVariable);
+  };
+
+  /** @return {!TemplateState | undefined} */
+  prototypeAccessors.currentTemplateState.get = function () {
+    return this.templateStack[this.templateStack.length - 1];
+  };
+
+  Object.defineProperties( State.prototype, prototypeAccessors );
+
+  var TemplateState = function TemplateState(kind, mode, state) {
+    /** @type {string} Either 'template' or 'inline-expression' */
+    this.kind = kind;
+    /**
+     * @type {?CodeMirror.Mode} If defined, the mode to tokenize
+     * the current template with. kind must be 'template' if this is defined.
+     */
+    this.mode = mode;
+    /** @type {?} The state object for this.mode. */
+    this.state = state;
+  };
+
+  TemplateState.prototype.copy = function copy () {
+    if (!this.mode) {
+      return new TemplateState(this.kind, null, null);
+    }
+    return new TemplateState(
+        this.kind, this.mode, CodeMirror.copyState(this.mode, this.state))
+  };
+
   var scopes = ["Block", "FunctionDef", "ArrowFunc", "ForStatement", "ParamListSpec"];
 
-  var TSMode = (function (superclass) {
+  var TSMode = /*@__PURE__*/(function (superclass) {
     function TSMode(conf, modeConf) {
       superclass.call(this, grammar, {
         predicates: {canInsertSemi: modeConf.requireSemicolons === false ? canInsertSemi : function () { return false; }}
       });
+      this.templateTokenizer = new TemplateTokenizer(conf);
       this.indentConf = {doubleIndentBrackets: ">)", dontCloseBrackets: ")", tabSize: conf.tabSize, indentUnit: conf.indentUnit};
     }
 
@@ -1187,8 +1564,34 @@
     TSMode.prototype = Object.create( superclass && superclass.prototype );
     TSMode.prototype.constructor = TSMode;
 
+    TSMode.prototype.startState = function startState () {
+      var state = superclass.prototype.startState.call(this);
+      state.embeddedParserState = this.templateTokenizer.startState();
+      return state;
+    };
+
+    TSMode.prototype.copyState = function copyState (state) {
+      var copy = superclass.prototype.copyState.call(this, state);
+      copy.embeddedParserState =
+          this.templateTokenizer.copyState(state.embeddedParserState);
+      return copy;
+    };
+
     TSMode.prototype.token = function token$$1 (stream, state) {
-      return markLocals(superclass.prototype.token.call(this, stream, state), scopes, stream, state)
+      var templateTokenizerState = state.embeddedParserState;
+      if (this.templateTokenizer
+            .shouldInterceptTokenizing(templateTokenizerState)) {
+        var ref = this.templateTokenizer
+            .interceptTokenizing(stream, templateTokenizerState);
+        var handled = ref.handled;
+        var style$1 = ref.style;
+        if (handled) {
+          return style$1;
+        }
+      }
+      var style = superclass.prototype.token.call(this, stream, state);
+      this.templateTokenizer.trackState(style, stream, templateTokenizerState);
+      return markLocals(style, scopes, stream, state)
     };
 
     TSMode.prototype.indent = function indent$1 (state, textAfter, line) {
@@ -1197,7 +1600,7 @@
     };
 
     return TSMode;
-  }(CodeMirror.GrammarMode));
+  }(CodeMirror$1.GrammarMode));
 
   var meta = {
     electricInput: /^\s*(?:case .*?:|default:|\{|\})$/,
@@ -1210,8 +1613,8 @@
   };
   for (var prop in meta) { TSMode.prototype[prop] = meta[prop]; }
 
-  CodeMirror.registerHelper("wordChars", "google-typescript", /[\w$]/);
+  CodeMirror$1.registerHelper("wordChars", "google-typescript", /[\w$]/);
 
-  CodeMirror.defineMode("google-typescript", function (conf, modeConf) { return new TSMode(conf, modeConf); });
+  CodeMirror$1.defineMode("google-typescript", function (conf, modeConf) { return new TSMode(conf, modeConf); });
 
 })));

--- a/src/template_string_inline_language.js
+++ b/src/template_string_inline_language.js
@@ -1,0 +1,419 @@
+/**
+ * @fileoverview Provides a class that facilitates tokenizing JavaScript tagged
+ * template string contents as a separate, embedded language.
+ *
+ * Consider code like:
+ *     html`<div>Hello ${'world'}</div>`
+ *
+ * For a good editing experience, the contents of that template string should
+ * be syntax highlighted as HTML.
+ *
+ * Doing this correctly in the limit is more difficult than it appears however,
+ * because arbitrary JS expressions are allowed inline, up to and including
+ * nesting of templates. This is even used in the real world. Consider:
+ *
+ * html`
+ *   <style>
+ *     ${css`
+ *       li {
+ *         color: green;
+ *       }
+ *     `}
+ *   </style>
+ *   <ul>
+ *     ${items.map(item => html`<li>${item}</li>`)}
+ *   </ul>
+ * `
+ */
+
+/**
+ * Use within a containing tokenizer to defer tokenizing the contents of some
+ * JavaScript tagged template literals to other CodeMirror language modes.
+ *
+ * This tokenizer is intended to be used from a JavaScript tokenizer, or
+ * one very similar to JavaScript, like TypeScript. It assumes that tagged
+ * template literals are tagged with the style 'string-2'.
+ *
+ * This class maintains its own state. Its state needs to be stored as part
+ * of the containing tokenizer's state, and copied when it is copied. See
+ * startState and copyState.
+ *
+ * Design goals:
+ *   - Minimally interfere with containing tokenizer, and make minimal
+ *     assumptions about its behavior.
+ *   - Have no impact on tokenizing code that does not use tagged template
+ *     literals, or tagged template literals that do not correspond to other
+ *     languages
+ *   - Defer tokenizing the contents of template strings to embedded language
+ *     modes but begin, end, and interrupt template strings according to the
+ *     JavaScript grammar.
+ *   - Parse correctly even for deeply nested combinations of literals inside
+ *     of literals.
+ *
+ * Known limitations:
+ *   - Embedded tokenizers will see JavaScript string escape sequences
+ *     (like \`, \\, etc), though semantically they should see the unescaped
+ *     values. This can confuse embedded tokenizers, though that confusion
+ *     will not spread outside of the template string.
+ */
+export class TemplateTokenizer {
+  constructor(config) {
+    this.config = config;
+  }
+
+  /** @return {!State} */
+  startState() {
+    return new State();
+  }
+
+  /**
+   * @param {!State} state
+   * @return {!State}
+   */
+  copyState(state) {
+    return state.copy();
+  }
+
+  /**
+   * If true, the containing tokenizer should defer to `interceptTokenizing`.
+   *
+   * @param {!State} state
+   */
+  shouldInterceptTokenizing(state) {
+    const templateState = state.currentTemplateState;
+    if (templateState !== undefined && templateState.mode !== null) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Defer to the embedded language tokenizer, but interrupt it for inline
+   * exprssions and the end of the template literal.
+   *
+   * This MUST only be called if shouldInterceptTokenizing is true for the
+   * current state.
+   *
+   * shouldInterceptTokenizing is separated out into its own
+   * method, even though this method also tells the containing tokenizer
+   * when it should defer to the embedded language because this method returns
+   * an object, and we don't want to allocate an extra object for each token
+   * consumed.
+   *
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @return {{handled: boolean, state: string|null}} If handled is true,
+   *     then the TS/JS tokenizer should not do any tokenizing of its own,
+   *     and return state. If handled is false, then this method has consumed
+   *     no input, and instead the TS/JS tokenizer should consume input instead.
+   */
+  interceptTokenizing(stream, state) {
+    // Check for an inline expression in the template literal.
+    if (stream.match('${')) {
+      stream.backUp(2);
+      if (!this.isEscaped(stream, stream.pos - 2)) {
+        // Hand things back to the normal tokenizer.
+        return {handled: false};
+      }
+    }
+    // Check for end of the template literal.
+    if (stream.peek() === '`' && !this.isEscaped(stream, stream.pos)) {
+      // Hand things back to the normal tokenizer.
+      return {handled: false};
+    }
+    // Important note for the above two early exit checks. We must first check
+    //   for the end characters, then check to see if they were escaped.
+    //   That avoids doing exponential work in the case where there's a long
+    //   sequence of backslashes that the embedded tokenizer consumes character
+    //   by character.
+
+    const {mode, state: innerState} = state.currentTemplateState;
+    const style = mode.token(stream, innerState);
+    this.backupIfEmbeddedTokenizerOvershot(stream);
+    return {handled: true, style};
+  }
+
+  /**
+   * Called after the containing tokenizer has consumed a token, but before
+   * that consumption is finalized.
+   *
+   * We keep track of entering and exiting template literals and inline
+   * expressions in template literals. In some cases, we reduce the
+   * amount of text consumed by the containing tokenizer, so that an embedded
+   * language has the opportunity to tokenize the contents of a template
+   * string that it controls.
+   *
+   * @param {string|null} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   */
+  trackState(style, stream, state) {
+    if (!style) {
+      return;
+    }
+    const templateState = state.currentTemplateState;
+    if (!templateState || templateState.kind === 'inline-expression') {
+      this.trackStateNotInTemplate(style, stream, state, templateState);
+    } else {
+      this.trackStateInTemplate(style, stream, state, templateState);
+    }
+    if (style === 'variable') {
+      state.previousVariable = stream.current();
+    } else {
+      state.previousVariable = null;
+    }
+  }
+
+  /**
+   * Maintain state.templateStack while not directly inside of a template
+   * literal.
+   *
+   * We could be inside of an inline expression in a template literal however.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {?TemplateState} templateState
+   */
+  trackStateNotInTemplate(style, stream, state, templateState) {
+    // Has the inline expression represented by embeddedMode just ended?
+    if (templateState && style === 'string-2' &&
+        stream.current().startsWith('}')) {
+      state.templateStack.pop();
+      // The containing tokenizer should only consume the } at this point.
+      stream.backUp(stream.current().length - 1);
+      return;
+    }
+    // Are we starting a new template?
+    if (style === 'string-2' &&
+      stream.current().startsWith('`')) {
+      const mode = this.getModeForTemplateTag(state.previousVariable);
+      const kind = 'template';
+      if (mode) {
+        // Nothing except the opening ` should be consumed.
+        stream.backUp(stream.current().length - 1);
+        state.templateStack.push(new TemplateState(
+          kind,
+          mode,
+          CodeMirror.startState(mode),
+        ));
+      } else {
+        state.templateStack.push(new TemplateState(kind, null, null));
+      }
+    }
+  }
+
+  /**
+   * Maintain state.templateStack while in the contents of a template literal.
+   *
+   * @private
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!State} state
+   * @param {!TemplateState} templateState
+   */
+  trackStateInTemplate(style, stream, state, templateState) {
+    // Is the current template ending?
+    if (style === 'string-2' && stream.current().endsWith('`') &&
+        !this.isEscaped(stream.pos - 1)) {
+      state.templateStack.pop();
+      return;
+    }
+
+    // Are we starting a new inline expression?
+    if (style === 'string-2' && stream.current().endsWith('${') &&
+        !this.isEscaped(stream.pos - 2)) {
+      state.templateStack.push(
+          new TemplateState('inline-expression', null, null));
+      return;
+    }
+  }
+
+  /**
+   * Inside of an inline template, we've let the embedded language tokenizer
+   * consume a token. However, it can't be allowed to consume text that actually
+   * indicates the end of that section of template literal string. If it has
+   * back up to right beforehand.
+   *
+   * @private
+   * @param {!Stream} stream
+   */
+  backupIfEmbeddedTokenizerOvershot(stream) {
+    const cur = stream.current();
+    let start = 0;
+    while(true) {
+      const closingIdx = cur.slice(start).search(/`|\$\{/);
+      if (closingIdx === -1) {
+        // no more potential escapes found, bail.
+        return;
+      }
+      const amountToBackUp = cur.length - (closingIdx + start);
+      const locationOfEarlyExit = stream.pos - amountToBackUp;
+      const escaped = this.isEscaped(stream, locationOfEarlyExit);
+      if (!escaped) {
+        // Found a real early exit. Bail out.
+        stream.backUp(cur.length - closingIdx);
+        return;
+      }
+      start = closingIdx;
+    }
+  }
+
+  /**
+   * Walks backwards from the given position in the stream looking for
+   * backslashes. Returns true if there are an odd number, and so the given
+   * position is string-escaped, and false if there are an even number.
+   *
+   * @private
+   * @param {!Stream} stream
+   * @param {number} start
+   */
+  isEscaped(stream, start) {
+    let escaped = false;
+    var idx = start;
+    while(idx > 0) {
+      if (stream.string[idx - 1] !== '\\') {
+        break;
+      }
+      escaped = !escaped;
+    }
+    return escaped;
+  }
+
+  /**
+   * @private
+   * @param {string|null} templateTag
+   */
+  getModeForTemplateTag(templateTag) {
+    if (!templateTag) {
+      return null;
+    }
+    // There are likely more customizations that would be nice here.
+    // Would be a good place for configuration if so.
+    if (templateTag === 'htm') {
+      templateTag = 'html';
+    }
+    const modeSpecs = [`google-${templateTag}`, `${templateTag}`];
+    // Note: the google-modules build pipeline does not currently support
+    //   for/of.
+    for (let i = 0; i < modeSpecs.length; i++) {
+      const mode = CodeMirror.getMode(this.config, modeSpecs[i]);
+      if (mode && mode.name !== 'null') {
+        return mode;
+      }
+    }
+    return null;
+  }
+}
+
+class State {
+  constructor(templateStack = [], previousVariable = null) {
+    /**
+     * A stack to keep track of the nesting of templates and inline expressions.
+     *
+     * Whenever we enter a template, we push a TemplateState with kind
+     * 'template' on the stack. Whenever, inside of a template, we enter
+     * an inline expression i.e. ${}, we push a TemplateState with kind
+     * 'inline-expression' on the stack. Likewise, as we leave templates and
+     * inline expressions we pop them off.
+     *
+     * A template that is being tokenized with an embedded CodeMirror mode will
+     * have a `mode` and its `state` on its associated TemplateState.
+     *
+     * @type {Array<!TemplateState>}
+     */
+    this.templateStack = templateStack;
+    /**
+     * Used to figure out the tag name of tagged template literals, to
+     * infer the inline language.
+     *
+     * @type {null|string}
+     */
+    this.previousVariable = previousVariable;
+  }
+
+  copy() {
+    return new State(
+        this.templateStack.map((t) => t.copy()), this.previousVariable);
+  }
+
+  /** @return {!TemplateState | undefined} */
+  get currentTemplateState() {
+    return this.templateStack[this.templateStack.length - 1];
+  }
+}
+
+class TemplateState {
+  /**
+   * @param {string} kind
+   * @param {?CodeMirror.Mode} mode
+   * @param {?} state
+   */
+  constructor(kind, mode, state) {
+    /** @type {string} Either 'template' or 'inline-expression' */
+    this.kind = kind;
+    /**
+     * @type {?CodeMirror.Mode} If defined, the mode to tokenize
+     *   the current template with. kind must be 'template' if this is defined.
+     */
+    this.mode = mode;
+    /** @type {?} The state object for this.mode. */
+    this.state = state;
+  }
+
+  copy() {
+    if (!this.mode) {
+      return new TemplateState(this.kind, null, null);
+    }
+    return new TemplateState(
+        this.kind, this.mode, CodeMirror.copyState(this.mode, this.state))
+  }
+}
+
+
+/**
+ * Just a basic type declaration describing a few parts of the CodeMirror stream
+ * API. Neither complete nor canonical.
+ *
+ * @record
+ */
+class Stream {
+  /**
+   * Returns the string value of the currently matched token.
+   *
+   * Can be called during tokenizing, in which case it returns what's been
+   * consumed so far.
+   *
+   * @return {string}
+   */
+  current() {}
+
+  /**
+   * Unconsumes `n` characters of input from the current token.
+   *
+   * @param {number} n
+   */
+  backUp(chars) {}
+
+  /**
+   * Tries to consume text matching the given value. Returns true if successful.
+   *
+   * @param {string|RegExp} v
+   * @return {boolean}
+   */
+  match(v) {}
+
+  /**
+   * Returns the next unconsumed character.
+   *
+   * @return {string}
+   */
+  peek() {}
+
+
+  constructor() {
+    /** @type {string} */
+    this.string;
+  }
+}

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -12,11 +12,36 @@ class TSMode extends CodeMirror.GrammarMode {
     super(grammar, {
       predicates: {canInsertSemi: modeConf.requireSemicolons === false ? canInsertSemi : () => false}
     })
+    this.embeddedParser = new EmbeddedLanguageParser(conf);
     this.indentConf = {doubleIndentBrackets: ">)", dontCloseBrackets: ")", tabSize: conf.tabSize, indentUnit: conf.indentUnit}
   }
 
+  startState() {
+    const state = super.startState();
+    state.embeddedParserState = this.embeddedParser.startState();
+    return state;
+  }
+
+  copyState(state) {
+    const copy = super.copyState(state);
+    copy.embeddedParserState =
+        this.embeddedParser.copyState(state.embeddedParserState);
+    return copy;
+  }
+
   token(stream, state) {
-    return markLocals(super.token(stream, state), scopes, stream, state)
+    const embeddedParserState = state.embeddedParserState;
+    if (this.embeddedParser.shouldInterceptTokenizing(embeddedParserState)) {
+      const {handled, style} = this.embeddedParser.interceptTokenizing(
+          stream, embeddedParserState);
+      if (handled) {
+        return style;
+      }
+    }
+    const style = super.token(stream, state);
+    this.embeddedParser.trackState(
+        style, stream, embeddedParserState);
+    return markLocals(style, scopes, stream, state)
   }
 
   indent(state, textAfter, line) {
@@ -24,6 +49,317 @@ class TSMode extends CodeMirror.GrammarMode {
     return indent(state, textAfter, line, this.indentConf)
   }
 }
+
+class EmbeddedLanguageParser {
+  constructor(config) {
+    this.config = config;
+  }
+
+  /** @return {!EmbeddedLanguageParserState} */
+  startState() {
+    return {
+      modeStack: [],
+      parseAsEmbeddedLanguage: false,
+      previousVariable: null,
+    };
+  }
+
+  /**
+   * @param {!EmbeddedLanguageParserState} state
+   * @return {!EmbeddedLanguageParserState}
+   */
+  copyState(state) {
+    return {
+      modeStack: state.modeStack.map((embeddedMode) => embeddedMode.copy()),
+      parseAsEmbeddedLanguage: state.parseAsEmbeddedLanguage,
+      previousVariable: state.previousVariable,
+    };
+  }
+
+  /**
+   * @param {!EmbeddedLanguageParserState} state
+   */
+  shouldInterceptTokenizing(state) {
+    const mode = state.modeStack[state.modeStack.length - 1];
+    if (mode !== undefined && mode.mode !== null) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @param {!Stream} stream
+   * @param {!EmbeddedLanguageParserState} state
+   */
+  interceptTokenizing(stream, state) {
+    // Check for an inline expression in the template literal.
+    if (stream.match('${')) {
+      stream.backUp(2);
+      if (!this.isEscaped(stream, stream.pos - 2)) {
+        // Hand things back to the normal parser.
+        state.parseAsEmbeddedLanguage = false;
+        return {handled: false};
+      }
+    }
+    // Check for end of the template literal.
+    // Note, here and above. First check for the escape, then check
+    //   to see if we're escaped. That avoids doing exponential work in
+    //   the case where there's a long sequence of backslashes that the
+    //   inner parser consumes character by character.
+    if (stream.peek() === '`' && !this.isEscaped(stream, stream.pos)) {
+      return {handled: false};
+    }
+    const {mode, state: innerState} =
+        state.modeStack[state.modeStack.length - 1];
+    const style = mode.token(stream, innerState);
+    this.backupIfEmbeddedParserOvershotClose(stream);
+    return {handled: true, style};
+  }
+
+  /**
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!EmbeddedLanguageParserState} state
+   */
+  trackState(style, stream, state) {
+    const embeddedMode = state.modeStack[state.modeStack.length - 1];
+    if (!embeddedMode || embeddedMode.kind === 'inline-expression') {
+      this.trackStateNotInTemplate(style, stream, state, embeddedMode);
+    } else {
+      this.trackStateInTemplate(style, stream, state, embeddedMode);
+    }
+    if (style === 'variable') {
+      state.previousVariable = stream.current();
+    } else {
+      state.previousVariable = null;
+    }
+  }
+
+  /**
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!EmbeddedLanguageParserState} state
+   * @param {?EmbeddedMode} embeddedMode
+   */
+  trackStateNotInTemplate(style, stream, state, embeddedMode) {
+    // Has the inline expression represented by embeddedMode just ended?
+    if (embeddedMode && style === 'string-2' &&
+        stream.current().startsWith('}')) {
+      debugger;
+      state.modeStack.pop();
+      const newEmbeddedMode = state.modeStack[state.modeStack.length - 1];
+      if (newEmbeddedMode && newEmbeddedMode.mode) {
+        state.parseAsEmbeddedLanguage = true;
+      }
+      // The JS parser should only consume the } at this point.
+      stream.backUp(stream.current().length - 1);
+      return;
+    }
+    // Are we starting a new template?
+    if (style === 'string-2' &&
+      stream.current().startsWith('`')) {
+      debugger;
+      const mode = this.getModeForTemplateTag(state.previousVariable);
+      const kind = 'template';
+      if (mode) {
+        // unparse everything except the opening `
+        stream.backUp(stream.current().length - 1);
+        state.modeStack.push(new EmbeddedMode(
+          kind,
+          mode,
+          CodeMirror.startState(mode),
+        ));
+        state.parseAsEmbeddedLanguage = true;
+      } else {
+        state.modeStack.push(new EmbeddedMode(kind, null, null));
+      }
+    }
+  }
+
+  /**
+   * @param {string} style
+   * @param {!Stream} stream
+   * @param {!EmbeddedLanguageParserState} state
+   * @param {!EmbeddedMode} embeddedMode
+   */
+  trackStateInTemplate(style, stream, state, embeddedMode) {
+    // Is the current template ending?
+    if (style === 'string-2' && stream.current().endsWith('`') &&
+        !this.isEscaped(stream.pos - 1)) {
+      debugger;
+      state.modeStack.pop();
+      return;
+    }
+
+    // Are we starting a new inline expression?
+    if (style === 'string-2' && stream.current().endsWith('${') &&
+        !this.isEscaped(stream.pos - 2)) {
+      debugger;
+      state.modeStack.push(new EmbeddedMode('inline-expression', null, null));
+      return;
+    }
+  }
+
+  /**
+   * Inside of an inline template, we've let the inner language parser consume
+   * a token. However, it can't be allowed to consume text that actually
+   * indicates the end of that section of template literal string. If it has
+   * back up to right beforehand.
+   *
+   * @private
+   * @param {!Stream} stream
+   */
+  backupIfEmbeddedParserOvershotClose(stream) {
+    const cur = stream.current();
+    let start = 0;
+    while(true) {
+      const closingIdx = cur.slice(start).search(/`|\$\{/);
+      if (closingIdx === -1) {
+        // no more potential escapes found, bail.
+        return;
+      }
+      const amountToBackUp = cur.length - (closingIdx + start);
+      const locationOfEarlyExit = stream.pos - amountToBackUp;
+      const escaped = this.isEscaped(stream, locationOfEarlyExit);
+      if (!escaped) {
+        // Found a real early exit. Bail out.
+        stream.backUp(cur.length - closingIdx);
+        return;
+      }
+      start = closingIdx;
+    }
+  }
+
+  /**
+   * Walks backwards from the given position in the stream looking for
+   * backslashes. Returns true if there are an odd number, and so the given
+   * position is string-escaped, and false if there are an even number.
+   *
+   * @param {!Stream} stream
+   * @param {number} start
+   */
+  isEscaped(stream, start) {
+    let escaped = false;
+    var idx = start;
+    while(idx > 0) {
+      if (stream.string[idx - 1] !== '\\') {
+        break;
+      }
+      escaped = !escaped;
+    }
+    return escaped;
+  }
+
+  /**
+   * @param {string|null} templateTag
+   * @private
+   */
+  getModeForTemplateTag(templateTag) {
+    if (!templateTag) {
+      return null;
+    }
+    const modeSpecs = [`google-${templateTag}`, `${templateTag}`];
+    // build pipeline does not support for/of currently.
+    for (let i = 0; i < modeSpecs.length; i++) {
+      const mode = CodeMirror.getMode(this.config, modeSpecs[i]);
+      if (mode && mode.name !== 'null') {
+        return mode;
+      }
+    }
+    return null;
+  }
+}
+
+class EmbeddedMode {
+  /**
+   * @param {string} kind
+   * @param {?CodeMirror.Mode} mode
+   * @param {?} state
+   */
+  constructor(kind, mode, state) {
+    /** @type {string} Either 'template' or 'inline-expression' */
+    this.kind = kind;
+    /**
+     * @type {?CodeMirror.Mode} If defined, the mode to parse
+     *   the current template with. kind must be 'template' if this is defined.
+     */
+    this.mode = mode;
+    /** @type {?} The state object for this.mode. */
+    this.state = state;
+  }
+
+  copy() {
+    if (!this.mode) {
+      return new EmbeddedMode(this.kind, null, null);
+    }
+    return new EmbeddedMode(
+        this.kind, this.mode, CodeMirror.copyState(this.mode, this.state))
+  }
+}
+
+/** @record */
+class EmbeddedLanguageParserState {
+  constructor() {
+    /**
+     * A stack of language modes. Last in, first out.
+     *
+     * This must be a stack to handle cases like:
+     *     html`<div>${spans.map(s => html`<span>${s}</span>`}`;
+     *
+     * @type {Array<EmbeddedMode}
+     */
+    this.modeStack;
+    // TODO(rictic): is parseAsEmbeddedLanguage at all necessary?
+    /**
+     * While true, we're inside an embedded language, and should defer
+     * to that language's parser. See interceptTokenizing().
+     *
+     * @type {boolean}
+     */
+    this.parseAsEmbeddedLanguage;
+    /**
+     * Used to figure out the tag name of tagged template literals, to
+     * infer the inline language.
+     *
+     * @type {null|string}
+     */
+    this.previousVariable;
+  }
+}
+
+/** @record */
+class Stream {
+  /**
+   * Returns the string value of the currently matched token.
+   *
+   * Can be called during tokenizing, in which case it returns what's been
+   * consumed so far.
+   *
+   * @return {string}
+   */
+  current() {}
+
+  /**
+   * Unconsumes `n` characters of input from the current token.
+   *
+   * @param {number} n
+   */
+  backUp(chars) {}
+
+  /**
+   * Tries to consume text matching the given value. Returns true if successful.
+   *
+   * @param {string|RegExp} v
+   * @return {boolean}
+   */
+  match(v) {}
+
+  constructor() {
+    /** @type {string} */
+    this.string;
+  }
+}
+
 
 let meta = {
   electricInput: /^\s*(?:case .*?:|default:|\{|\})$/,

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -4,6 +4,7 @@ import * as grammar from "./typescript.mode"
 import {markLocals} from "./locals"
 import {indent} from "./c_indent"
 import {canInsertSemi} from "./js_semi"
+import {TemplateTokenizer} from "./template_string_inline_language";
 
 const scopes = ["Block", "FunctionDef", "ArrowFunc", "ForStatement", "ParamListSpec"]
 
@@ -12,35 +13,35 @@ class TSMode extends CodeMirror.GrammarMode {
     super(grammar, {
       predicates: {canInsertSemi: modeConf.requireSemicolons === false ? canInsertSemi : () => false}
     })
-    this.embeddedParser = new EmbeddedLanguageParser(conf);
+    this.templateTokenizer = new TemplateTokenizer(conf);
     this.indentConf = {doubleIndentBrackets: ">)", dontCloseBrackets: ")", tabSize: conf.tabSize, indentUnit: conf.indentUnit}
   }
 
   startState() {
     const state = super.startState();
-    state.embeddedParserState = this.embeddedParser.startState();
+    state.embeddedParserState = this.templateTokenizer.startState();
     return state;
   }
 
   copyState(state) {
     const copy = super.copyState(state);
     copy.embeddedParserState =
-        this.embeddedParser.copyState(state.embeddedParserState);
+        this.templateTokenizer.copyState(state.embeddedParserState);
     return copy;
   }
 
   token(stream, state) {
-    const embeddedParserState = state.embeddedParserState;
-    if (this.embeddedParser.shouldInterceptTokenizing(embeddedParserState)) {
-      const {handled, style} = this.embeddedParser.interceptTokenizing(
-          stream, embeddedParserState);
+    const templateTokenizerState = state.embeddedParserState;
+    if (this.templateTokenizer
+          .shouldInterceptTokenizing(templateTokenizerState)) {
+      const {handled, style} = this.templateTokenizer
+          .interceptTokenizing(stream, templateTokenizerState);
       if (handled) {
         return style;
       }
     }
     const style = super.token(stream, state);
-    this.embeddedParser.trackState(
-        style, stream, embeddedParserState);
+    this.templateTokenizer.trackState(style, stream, templateTokenizerState);
     return markLocals(style, scopes, stream, state)
   }
 
@@ -49,317 +50,6 @@ class TSMode extends CodeMirror.GrammarMode {
     return indent(state, textAfter, line, this.indentConf)
   }
 }
-
-class EmbeddedLanguageParser {
-  constructor(config) {
-    this.config = config;
-  }
-
-  /** @return {!EmbeddedLanguageParserState} */
-  startState() {
-    return {
-      modeStack: [],
-      parseAsEmbeddedLanguage: false,
-      previousVariable: null,
-    };
-  }
-
-  /**
-   * @param {!EmbeddedLanguageParserState} state
-   * @return {!EmbeddedLanguageParserState}
-   */
-  copyState(state) {
-    return {
-      modeStack: state.modeStack.map((embeddedMode) => embeddedMode.copy()),
-      parseAsEmbeddedLanguage: state.parseAsEmbeddedLanguage,
-      previousVariable: state.previousVariable,
-    };
-  }
-
-  /**
-   * @param {!EmbeddedLanguageParserState} state
-   */
-  shouldInterceptTokenizing(state) {
-    const mode = state.modeStack[state.modeStack.length - 1];
-    if (mode !== undefined && mode.mode !== null) {
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * @param {!Stream} stream
-   * @param {!EmbeddedLanguageParserState} state
-   */
-  interceptTokenizing(stream, state) {
-    // Check for an inline expression in the template literal.
-    if (stream.match('${')) {
-      stream.backUp(2);
-      if (!this.isEscaped(stream, stream.pos - 2)) {
-        // Hand things back to the normal parser.
-        state.parseAsEmbeddedLanguage = false;
-        return {handled: false};
-      }
-    }
-    // Check for end of the template literal.
-    // Note, here and above. First check for the escape, then check
-    //   to see if we're escaped. That avoids doing exponential work in
-    //   the case where there's a long sequence of backslashes that the
-    //   inner parser consumes character by character.
-    if (stream.peek() === '`' && !this.isEscaped(stream, stream.pos)) {
-      return {handled: false};
-    }
-    const {mode, state: innerState} =
-        state.modeStack[state.modeStack.length - 1];
-    const style = mode.token(stream, innerState);
-    this.backupIfEmbeddedParserOvershotClose(stream);
-    return {handled: true, style};
-  }
-
-  /**
-   * @param {string} style
-   * @param {!Stream} stream
-   * @param {!EmbeddedLanguageParserState} state
-   */
-  trackState(style, stream, state) {
-    const embeddedMode = state.modeStack[state.modeStack.length - 1];
-    if (!embeddedMode || embeddedMode.kind === 'inline-expression') {
-      this.trackStateNotInTemplate(style, stream, state, embeddedMode);
-    } else {
-      this.trackStateInTemplate(style, stream, state, embeddedMode);
-    }
-    if (style === 'variable') {
-      state.previousVariable = stream.current();
-    } else {
-      state.previousVariable = null;
-    }
-  }
-
-  /**
-   * @param {string} style
-   * @param {!Stream} stream
-   * @param {!EmbeddedLanguageParserState} state
-   * @param {?EmbeddedMode} embeddedMode
-   */
-  trackStateNotInTemplate(style, stream, state, embeddedMode) {
-    // Has the inline expression represented by embeddedMode just ended?
-    if (embeddedMode && style === 'string-2' &&
-        stream.current().startsWith('}')) {
-      debugger;
-      state.modeStack.pop();
-      const newEmbeddedMode = state.modeStack[state.modeStack.length - 1];
-      if (newEmbeddedMode && newEmbeddedMode.mode) {
-        state.parseAsEmbeddedLanguage = true;
-      }
-      // The JS parser should only consume the } at this point.
-      stream.backUp(stream.current().length - 1);
-      return;
-    }
-    // Are we starting a new template?
-    if (style === 'string-2' &&
-      stream.current().startsWith('`')) {
-      debugger;
-      const mode = this.getModeForTemplateTag(state.previousVariable);
-      const kind = 'template';
-      if (mode) {
-        // unparse everything except the opening `
-        stream.backUp(stream.current().length - 1);
-        state.modeStack.push(new EmbeddedMode(
-          kind,
-          mode,
-          CodeMirror.startState(mode),
-        ));
-        state.parseAsEmbeddedLanguage = true;
-      } else {
-        state.modeStack.push(new EmbeddedMode(kind, null, null));
-      }
-    }
-  }
-
-  /**
-   * @param {string} style
-   * @param {!Stream} stream
-   * @param {!EmbeddedLanguageParserState} state
-   * @param {!EmbeddedMode} embeddedMode
-   */
-  trackStateInTemplate(style, stream, state, embeddedMode) {
-    // Is the current template ending?
-    if (style === 'string-2' && stream.current().endsWith('`') &&
-        !this.isEscaped(stream.pos - 1)) {
-      debugger;
-      state.modeStack.pop();
-      return;
-    }
-
-    // Are we starting a new inline expression?
-    if (style === 'string-2' && stream.current().endsWith('${') &&
-        !this.isEscaped(stream.pos - 2)) {
-      debugger;
-      state.modeStack.push(new EmbeddedMode('inline-expression', null, null));
-      return;
-    }
-  }
-
-  /**
-   * Inside of an inline template, we've let the inner language parser consume
-   * a token. However, it can't be allowed to consume text that actually
-   * indicates the end of that section of template literal string. If it has
-   * back up to right beforehand.
-   *
-   * @private
-   * @param {!Stream} stream
-   */
-  backupIfEmbeddedParserOvershotClose(stream) {
-    const cur = stream.current();
-    let start = 0;
-    while(true) {
-      const closingIdx = cur.slice(start).search(/`|\$\{/);
-      if (closingIdx === -1) {
-        // no more potential escapes found, bail.
-        return;
-      }
-      const amountToBackUp = cur.length - (closingIdx + start);
-      const locationOfEarlyExit = stream.pos - amountToBackUp;
-      const escaped = this.isEscaped(stream, locationOfEarlyExit);
-      if (!escaped) {
-        // Found a real early exit. Bail out.
-        stream.backUp(cur.length - closingIdx);
-        return;
-      }
-      start = closingIdx;
-    }
-  }
-
-  /**
-   * Walks backwards from the given position in the stream looking for
-   * backslashes. Returns true if there are an odd number, and so the given
-   * position is string-escaped, and false if there are an even number.
-   *
-   * @param {!Stream} stream
-   * @param {number} start
-   */
-  isEscaped(stream, start) {
-    let escaped = false;
-    var idx = start;
-    while(idx > 0) {
-      if (stream.string[idx - 1] !== '\\') {
-        break;
-      }
-      escaped = !escaped;
-    }
-    return escaped;
-  }
-
-  /**
-   * @param {string|null} templateTag
-   * @private
-   */
-  getModeForTemplateTag(templateTag) {
-    if (!templateTag) {
-      return null;
-    }
-    const modeSpecs = [`google-${templateTag}`, `${templateTag}`];
-    // build pipeline does not support for/of currently.
-    for (let i = 0; i < modeSpecs.length; i++) {
-      const mode = CodeMirror.getMode(this.config, modeSpecs[i]);
-      if (mode && mode.name !== 'null') {
-        return mode;
-      }
-    }
-    return null;
-  }
-}
-
-class EmbeddedMode {
-  /**
-   * @param {string} kind
-   * @param {?CodeMirror.Mode} mode
-   * @param {?} state
-   */
-  constructor(kind, mode, state) {
-    /** @type {string} Either 'template' or 'inline-expression' */
-    this.kind = kind;
-    /**
-     * @type {?CodeMirror.Mode} If defined, the mode to parse
-     *   the current template with. kind must be 'template' if this is defined.
-     */
-    this.mode = mode;
-    /** @type {?} The state object for this.mode. */
-    this.state = state;
-  }
-
-  copy() {
-    if (!this.mode) {
-      return new EmbeddedMode(this.kind, null, null);
-    }
-    return new EmbeddedMode(
-        this.kind, this.mode, CodeMirror.copyState(this.mode, this.state))
-  }
-}
-
-/** @record */
-class EmbeddedLanguageParserState {
-  constructor() {
-    /**
-     * A stack of language modes. Last in, first out.
-     *
-     * This must be a stack to handle cases like:
-     *     html`<div>${spans.map(s => html`<span>${s}</span>`}`;
-     *
-     * @type {Array<EmbeddedMode}
-     */
-    this.modeStack;
-    // TODO(rictic): is parseAsEmbeddedLanguage at all necessary?
-    /**
-     * While true, we're inside an embedded language, and should defer
-     * to that language's parser. See interceptTokenizing().
-     *
-     * @type {boolean}
-     */
-    this.parseAsEmbeddedLanguage;
-    /**
-     * Used to figure out the tag name of tagged template literals, to
-     * infer the inline language.
-     *
-     * @type {null|string}
-     */
-    this.previousVariable;
-  }
-}
-
-/** @record */
-class Stream {
-  /**
-   * Returns the string value of the currently matched token.
-   *
-   * Can be called during tokenizing, in which case it returns what's been
-   * consumed so far.
-   *
-   * @return {string}
-   */
-  current() {}
-
-  /**
-   * Unconsumes `n` characters of input from the current token.
-   *
-   * @param {number} n
-   */
-  backUp(chars) {}
-
-  /**
-   * Tries to consume text matching the given value. Returns true if successful.
-   *
-   * @param {string|RegExp} v
-   * @return {boolean}
-   */
-  match(v) {}
-
-  constructor() {
-    /** @type {string} */
-    this.string;
-  }
-}
-
 
 let meta = {
   electricInput: /^\s*(?:case .*?:|default:|\{|\})$/,

--- a/test/js/tagged_template.js
+++ b/test/js/tagged_template.js
@@ -1,0 +1,49 @@
+[comment // normal template]
+[string-2 `hello`];
+
+[comment // inline html]
+[variable html][string-2 `][tag <div>][string-2 `];
+
+[comment // expression inside inline html]
+[variable html][string-2 `][tag <div>][string-2 ${][number 10]
+    [string-2 }][string-2 `];
+
+[comment // normal template inside inline html]
+[variable html][string-2 `][tag <div>][string-2 ${]
+    [variable foo][string-2 `][string-2 <span>][string-2 `]
+    [string-2 }][tag </div>][string-2 `];
+
+[comment // inline html inside of inline html]
+[variable html][string-2 `][tag <div>][string-2 ${]
+    [variable html][string-2 `][tag <span>][string-2 `]
+    [string-2 }][tag </div>][string-2 `];
+
+
+
+[comment // tricky escape sequences]
+
+[variable html][string-2 ``];
+[variable html][string-2 `]\`;
+    [string-2 `]; [comment // close the unclosed from prev line]
+[variable html][string-2 `]\`[string-2 `];
+
+[comment // escaped backticks are matched by inner language]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\`"][tag >]
+    [tag </div>][string-2 `];
+
+[comment // any odd number of backslashes is fine]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\`"][tag >]
+    [tag </div>][string-2 `];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\\`"][tag >]
+    [tag </div>][string-2 `];
+
+[comment // an even number of backslashes do not escape, the template ends.]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\][string-2 `][string ">"];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\][string-2 `][string ">"];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\\\][string-2 `][string ">"];

--- a/test/js/tagged_template.js
+++ b/test/js/tagged_template.js
@@ -22,6 +22,8 @@
 
 [comment // tricky escape sequences]
 
+[comment // escaped backticks]
+
 [variable html][string-2 ``];
 [variable html][string-2 `]\`;
     [string-2 `]; [comment // close the unclosed from prev line]
@@ -47,3 +49,10 @@
     [tag <div] [attribute attr]=[string "\\\\][string-2 `][string ">"];
 [variable html][string-2 `]
     [tag <div] [attribute attr]=[string "\\\\\\][string-2 `][string ">"];
+
+[comment // escaped inner expressions]
+
+[variable html][string-2 `${][number 10][string-2 }`];
+[variable html][string-2 `]\\[string-2 ${][number 10][string-2 }`];
+[variable html][string-2 `]\\\\[string-2 ${][number 10][string-2 }`];
+[variable html][string-2 `]\${10}[string-2 `];

--- a/test/run.js
+++ b/test/run.js
@@ -16,6 +16,7 @@ require("../dist/go")
 require("../dist/java")
 require("../dist/kotlin")
 require("../dist/angulartemplate")
+require("../dist/html")
 
 let filter = process.argv[2]
 
@@ -40,8 +41,8 @@ let filter = process.argv[2]
     } catch(e) {
       console.log(`${file}: ${e.stack || e.message}`)
     }
-  })
-})
+  });
+});
 
 function parseTestSpec(file, fileName) {
   let directive = /(?:\/\/|#)\s*test:\s*(.*)/.exec(file)
@@ -65,7 +66,8 @@ function compare(text, tokens, mode, open) {
     let token = tokens[index], type = tokenType(style)
     if (token.type != type && !(open && token.type == null)) {
       let shortText = token.text.length < text.length ? token.text : text
-      throw new Error(`Unexpected token ${JSON.stringify(type)} for ${JSON.stringify(shortText)} at ${line}:${ch}. Expected ${JSON.stringify(token.type)}`)
+      let underlined = `    ${lines[line - 1]}\n    ${' '.repeat(ch)}^`;
+      throw new Error(`Unexpected token ${JSON.stringify(type)} for ${JSON.stringify(shortText)} at ${line}:${ch}. Expected ${JSON.stringify(token.type)}\n${underlined}`)
     }
 
     if (text == "\n") {

--- a/test/ts/tagged_template.ts
+++ b/test/ts/tagged_template.ts
@@ -1,0 +1,49 @@
+[comment // normal template]
+[string-2 `hello`];
+
+[comment // inline html]
+[variable html][string-2 `][tag <div>][string-2 `];
+
+[comment // expression inside inline html]
+[variable html][string-2 `][tag <div>][string-2 ${][number 10]
+    [string-2 }][string-2 `];
+
+[comment // normal template inside inline html]
+[variable html][string-2 `][tag <div>][string-2 ${]
+    [variable foo][string-2 `][string-2 <span>][string-2 `]
+    [string-2 }][tag </div>][string-2 `];
+
+[comment // inline html inside of inline html]
+[variable html][string-2 `][tag <div>][string-2 ${]
+    [variable html][string-2 `][tag <span>][string-2 `]
+    [string-2 }][tag </div>][string-2 `];
+
+
+
+[comment // tricky escape sequences]
+
+[variable html][string-2 ``];
+[variable html][string-2 `]\`;
+    [string-2 `]; [comment // close the unclosed from prev line]
+[variable html][string-2 `]\`[string-2 `];
+
+[comment // escaped backticks are matched by inner language]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\`"][tag >]
+    [tag </div>][string-2 `];
+
+[comment // any odd number of backslashes is fine]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\`"][tag >]
+    [tag </div>][string-2 `];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\\`"][tag >]
+    [tag </div>][string-2 `];
+
+[comment // an even number of backslashes do not escape, the template ends.]
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\][string-2 `][string ">"];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\][string-2 `][string ">"];
+[variable html][string-2 `]
+    [tag <div] [attribute attr]=[string "\\\\\\][string-2 `][string ">"];

--- a/test/ts/tagged_template.ts
+++ b/test/ts/tagged_template.ts
@@ -22,6 +22,8 @@
 
 [comment // tricky escape sequences]
 
+[comment // escaped backticks]
+
 [variable html][string-2 ``];
 [variable html][string-2 `]\`;
     [string-2 `]; [comment // close the unclosed from prev line]
@@ -47,3 +49,10 @@
     [tag <div] [attribute attr]=[string "\\\\][string-2 `][string ">"];
 [variable html][string-2 `]
     [tag <div] [attribute attr]=[string "\\\\\\][string-2 `][string ">"];
+
+[comment // escaped inner expressions]
+
+[variable html][string-2 `${][number 10][string-2 }`];
+[variable html][string-2 `]\\[string-2 ${][number 10][string-2 }`];
+[variable html][string-2 `]\\\\[string-2 ${][number 10][string-2 }`];
+[variable html][string-2 `]\${10}[string-2 `];


### PR DESCRIPTION
Consider code like:
```javascript
     html`<div>Hello ${'world'}</div>`
```

For a good editing experience, the contents of that template string should
be syntax highlighted as HTML.

In the limit, this is more difficult than it initially appears however, because arbitrary JS expressions are allowed inline, including nested templates. Perhaps surprisingly, this is used used in real world code like the following:

```javascript
html`
  <style>
    ${css`
      li {
        color: green;
      }
    `}
  </style>
  <ul>
    ${items.map(item => html`<li>${item}</li>`)}
  </ul>
`;
```

Care was taken in this implementation to impose minimal cost on unrelated code, and to keep the implementation complexity for this feature silo'd away from the JS and TS parsers.