### PR TITLE
[py] Allowed trailing comma and newlines in a parenthesized from-import

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -29,11 +29,13 @@ skip whitespace {
     returnAssert Expr? |
     raise Expr? (from Expr)? |
     import CommaSep(ExprNoComma (as declName)?) |
-    from "."* Expr? import ("*" | "(" CommaSep(identifier (as declName?))? ")" | CommaSep(identifier (as declName)?)) |
+    from "."* Expr? import ("*" | FromImportList | CommaSep(identifier (as declName)?)) |
     globalNonlocal CommaSep(variableName) |
     MaybePattern(("=" | ":")) (":" Expr)? (op("=") Expr)? |
     Expr
   }
+
+  context FromImportList { "(" CommaSep(identifier (as declName)?)? ","? ")" }
 
   Annotation="meta" { "@" identifier ("." identifier)* }
 

--- a/src/python.js
+++ b/src/python.js
@@ -4,7 +4,7 @@ import * as grammar from "./python.mode"
 import {markLocals} from "./locals"
 
 const scopes = ["LambdaDef", "FuncDef", "ClassDef"]
-const allowNewline = ["ArgList", "ParamList", "ParenExpr", "ArrayLiteral", "ObjectLiteral", "Subscript", "DictProp", "ParenPattern", "BracketPattern"]
+const allowNewline = ["ArgList", "ParamList", "FromImportList", "ParenExpr", "ArrayLiteral", "ObjectLiteral", "Subscript", "DictProp", "ParenPattern", "BracketPattern"]
 
 function maySkipNewline(_line, _pos, cx) {
   return cx && allowNewline.indexOf(cx.name) > -1
@@ -74,7 +74,7 @@ function pythonMarkLocals(token, stream, state) {
     else if (marked == "def local") marked = "variable-2"
   }
   return marked
-}  
+}
 
 class PythonMode extends CodeMirror.GrammarMode {
   constructor(conf) {

--- a/test/py/grammar.py
+++ b/test/py/grammar.py
@@ -1,7 +1,12 @@
 [comment # this is a comment]
 
-[keyword import] [variable foo].[property bar] [keyword as] [def ugh]
-[keyword from] [variable huh] [keyword import] *
+[keyword import] [variable foo].[property bar] [keyword as] [def foobar]
+[keyword from] [variable foo] [keyword import] *
+[keyword from] [variable foo] [keyword import] bar
+[keyword from] [variable foo] [keyword import] bar [keyword as] [def foobar]
+[keyword from] [variable foo] [keyword import] (bar)
+[keyword from] [variable foo] [keyword import] (bar [keyword as] [def foobar])
+[keyword from] [variable foo] [keyword import] (bar,)
 
 [def foo] [operator =] [string "bar"]; [variable abc_cde].[property&callee prop]([operator **][variable baz]); [keyword del] [variable foo], [variable bar]
 [def bar]: [builtin str] [operator =] [string "q"]


### PR DESCRIPTION
Note that Python mode currently has multiple special-cased contexts for
parenthesized "things" where newlines are ignored. According to
https://docs.python.org/3/reference/lexical_analysis.html#implicit-line-joining
whitespace and comments are always ignored inside parens/brackets/braces.
Perhaps, we could clean this up in a followup.