### PR TITLE
[clif] Added indentation support

### DIFF
--- a/dist/clif.js
+++ b/dist/clif.js
@@ -4,932 +4,406 @@
   (factory(global.CodeMirror));
 }(this, (function (CodeMirror) { 'use strict';
 
-  var nodes = {
-    "_start": [
-      1, "whitespace", "_start$2"
-    ],
-    "_start$1": [
-      /^[^]/, "_start"
-    ],
-    "_start$2": [
-      1, "whitespace", "_start$3"
-    ],
-    "_start$3": [
-      "\n", "_start$4",
-      2, "Statement", "_start$4", {"name":"Statement"},
-      0, "_start$1"
-    ],
-    "_start$4": [
-      1, "whitespace", "_start$3"
-    ],
-    "_token": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^capsule(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^class(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^const(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^def(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^default(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^enum(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^implements(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^import(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^interface(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^lambda(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^namespace(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^pass(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^property(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^return(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^staticmethods(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^type(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^use(?![a-zA-Z0-9_])/, -1,
-      3, "keyword", /^with(?![a-zA-Z0-9_])/, -1,
-      3, "atom", /^None(?![a-zA-Z0-9_])/, -1,
-      3, "atom", /^(?:self|cls)(?![a-zA-Z0-9_])/, -1,
-      3, "comment", /^\#.*/, -1,
-      /^[^]/, -1
-    ],
-    "whitespace": [
-      /^[ \t]/, "whitespace",
-      3, "comment", /^\#.*/, "whitespace",
-      [0, /^(?=\n)/, [7, "maySkipNewline"]], "whitespace$1",
-      0, -1
-    ],
-    "whitespace$1": [
-      "\n", "whitespace"
-    ],
-    "Statement": [
-      [6, "_lookahead"], "Statement$1",
-      1, "InterfaceStatement", -1,
-      3, "keyword", /^def(?![a-zA-Z0-9_])/, "Statement$8",
-      3, "keyword", /^class(?![a-zA-Z0-9_])/, "Statement$20",
-      3, "keyword", /^enum(?![a-zA-Z0-9_])/, "Statement$28",
-      1, "InterfaceStatement", -1,
-      3, "keyword", /^staticmethods(?![a-zA-Z0-9_])/, "Statement$36",
-      3, "keyword", /^namespace(?![a-zA-Z0-9_])/, "Statement$44",
-      3, "keyword", /^capsule(?![a-zA-Z0-9_])/, "Statement$50",
-      3, "keyword", /^implements(?![a-zA-Z0-9_])/, "Statement$51",
-      [6, "_lookahead_1"], "Statement$52",
-      [6, "_lookahead_2"], "Statement$53",
-      3, "keyword", /^use(?![a-zA-Z0-9_])/, "Statement$54",
-      3, "keyword", /^type(?![a-zA-Z0-9_])/, "Statement$55",
-      3, "keyword", /^const(?![a-zA-Z0-9_])/, "Statement$56",
-      [5, "_lookahead_3"], "Statement$57",
-      2, "Decorator", "Statement$58", {"name":"Decorator","token":"meta"},
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$59",
-      3, "keyword", /^pass(?![a-zA-Z0-9_])/, "Statement$58",
-      2, "qstring", "Statement$60", {"name":"qstring","token":"string"},
-      3, "keyword", /^return(?![a-zA-Z0-9_])/, "Statement$61",
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$62"
-    ],
-    "Statement$1": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "Statement$2"
-    ],
-    "Statement$2": [
-      1, "whitespace", "Statement$3"
-    ],
-    "Statement$3": [
-      2, "qstring", "Statement$4", {"name":"qstring","token":"string"}
-    ],
-    "Statement$4": [
-      1, "whitespace", "Statement$5"
-    ],
-    "Statement$5": [
-      ":", "Statement$6"
-    ],
-    "Statement$6": [
-      1, "whitespace", "Statement$7"
-    ],
-    "Statement$7": [
-      1, "indentedBody", -1
-    ],
-    "Statement$8": [
-      1, "whitespace", "Statement$9"
-    ],
-    "Statement$9": [
-      1, "cname", "Statement$10"
-    ],
-    "Statement$10": [
-      1, "whitespace", "Statement$11"
-    ],
-    "Statement$11": [
-      2, "Params", "Statement$12", {"name":"Params"}
-    ],
-    "Statement$12": [
-      1, "whitespace", "Statement$13"
-    ],
-    "Statement$13": [
-      "->", "Statement$14",
-      0, -1
-    ],
-    "Statement$14": [
-      1, "whitespace", "Statement$15"
-    ],
-    "Statement$15": [
-      3, "atom", /^None(?![a-zA-Z0-9_])/, "Statement$16",
-      1, "Type", "Statement$16",
-      2, "Params", "Statement$16", {"name":"Params"}
-    ],
-    "Statement$16": [
-      1, "whitespace", "Statement$17"
-    ],
-    "Statement$17": [
-      ":", "Statement$18",
-      0, -1
-    ],
-    "Statement$18": [
-      1, "whitespace", "Statement$19"
-    ],
-    "Statement$19": [
-      1, "indentedBody", -1
-    ],
-    "Statement$20": [
-      1, "whitespace", "Statement$21"
-    ],
-    "Statement$21": [
-      1, "cname", "Statement$22"
-    ],
-    "Statement$22": [
-      1, "whitespace", "Statement$23"
-    ],
-    "Statement$23": [
-      2, "Bases", "Statement$24", {"name":"Bases"},
-      0, "Statement$24"
-    ],
-    "Statement$24": [
-      1, "whitespace", "Statement$25"
-    ],
-    "Statement$25": [
-      ":", "Statement$26"
-    ],
-    "Statement$26": [
-      1, "whitespace", "Statement$27"
-    ],
-    "Statement$27": [
-      1, "indentedBody", -1
-    ],
-    "Statement$28": [
-      1, "whitespace", "Statement$29"
-    ],
-    "Statement$29": [
-      1, "cname", "Statement$30"
-    ],
-    "Statement$30": [
-      1, "whitespace", "Statement$31"
-    ],
-    "Statement$31": [
-      3, "keyword", /^with(?![a-zA-Z0-9_])/, "Statement$32",
-      0, -1
-    ],
-    "Statement$32": [
-      1, "whitespace", "Statement$33"
-    ],
-    "Statement$33": [
-      ":", "Statement$34"
-    ],
-    "Statement$34": [
-      1, "whitespace", "Statement$35"
-    ],
-    "Statement$35": [
-      1, "indentedBody", -1
-    ],
-    "Statement$36": [
-      1, "whitespace", "Statement$37"
-    ],
-    "Statement$37": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "Statement$38"
-    ],
-    "Statement$38": [
-      1, "whitespace", "Statement$39"
-    ],
-    "Statement$39": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$40"
-    ],
-    "Statement$40": [
-      1, "whitespace", "Statement$41"
-    ],
-    "Statement$41": [
-      ":", "Statement$42"
-    ],
-    "Statement$42": [
-      1, "whitespace", "Statement$43"
-    ],
-    "Statement$43": [
-      1, "indentedBody", -1
-    ],
-    "Statement$44": [
-      1, "whitespace", "Statement$45"
-    ],
-    "Statement$45": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$46"
-    ],
-    "Statement$46": [
-      1, "whitespace", "Statement$47"
-    ],
-    "Statement$47": [
-      ":", "Statement$48"
-    ],
-    "Statement$48": [
-      1, "whitespace", "Statement$49"
-    ],
-    "Statement$49": [
-      1, "indentedBody", -1
-    ],
-    "Statement$50": [
-      1, "whitespace", "Statement$63"
-    ],
-    "Statement$51": [
-      1, "whitespace", "Statement$64"
-    ],
-    "Statement$52": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "Statement$65"
-    ],
-    "Statement$53": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "Statement$66"
-    ],
-    "Statement$54": [
-      1, "whitespace", "Statement$67"
-    ],
-    "Statement$55": [
-      1, "whitespace", "Statement$68"
-    ],
-    "Statement$56": [
-      1, "whitespace", "Statement$69"
-    ],
-    "Statement$57": [
-      1, "cname", "Statement$70"
-    ],
-    "Statement$58": [
-      1, "whitespace", "Statement$71"
-    ],
-    "Statement$59": [
-      1, "whitespace", "Statement$72"
-    ],
-    "Statement$60": [
-      1, "whitespace", "Statement$73"
-    ],
-    "Statement$61": [
-      1, "whitespace", "Statement$74"
-    ],
-    "Statement$62": [
-      1, "whitespace", "Statement$75"
-    ],
-    "Statement$63": [
-      1, "cname", "Statement$58"
-    ],
-    "Statement$64": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$76"
-    ],
-    "Statement$65": [
-      1, "whitespace", "Statement$77"
-    ],
-    "Statement$66": [
-      1, "whitespace", "Statement$78"
-    ],
-    "Statement$67": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$79"
-    ],
-    "Statement$68": [
-      3, "def", /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$80"
-    ],
-    "Statement$69": [
-      2, "d_1", "Statement$81", {"name":"d","token":"def"}
-    ],
-    "Statement$70": [
-      1, "whitespace", "Statement$82"
-    ],
-    "Statement$71": [
-      "\n", -1
-    ],
-    "Statement$72": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "Statement$83"
-    ],
-    "Statement$73": [
-      [6, "_lookahead_4"], "Statement$58"
-    ],
-    "Statement$74": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$84"
-    ],
-    "Statement$75": [
-      /^(?!\:)/, "Statement$58"
-    ],
-    "Statement$76": [
-      1, "whitespace", "Statement$85"
-    ],
-    "Statement$77": [
-      1, "DottedName", "Statement$86"
-    ],
-    "Statement$78": [
-      2, "qstring", "Statement$87", {"name":"qstring","token":"string"}
-    ],
-    "Statement$79": [
-      1, "whitespace", "Statement$88"
-    ],
-    "Statement$80": [
-      1, "whitespace", "Statement$89"
-    ],
-    "Statement$81": [
-      1, "whitespace", "Statement$90"
-    ],
-    "Statement$82": [
-      ":", "Statement$91"
-    ],
-    "Statement$83": [
-      1, "whitespace", "Statement$92"
-    ],
-    "Statement$84": [
-      1, "whitespace", "Statement$93"
-    ],
-    "Statement$85": [
-      "<", "Statement$94"
-    ],
-    "Statement$86": [
-      1, "whitespace", "Statement$95"
-    ],
-    "Statement$87": [
-      1, "whitespace", "Statement$96"
-    ],
-    "Statement$88": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "Statement$97"
-    ],
-    "Statement$89": [
-      "=", "Statement$98"
-    ],
-    "Statement$90": [
-      ":", "Statement$99"
-    ],
-    "Statement$91": [
-      1, "whitespace", "Statement$100"
-    ],
-    "Statement$92": [
-      1, "DottedName", "Statement$58"
-    ],
-    "Statement$93": [
-      "(", "Statement$101"
-    ],
-    "Statement$94": [
-      1, "whitespace", "Statement$102"
-    ],
-    "Statement$95": [
-      3, "keyword", /^import(?![a-zA-Z0-9_])/, "Statement$103"
-    ],
-    "Statement$96": [
-      3, "keyword", /^import(?![a-zA-Z0-9_])/, "Statement$104"
-    ],
-    "Statement$97": [
-      1, "whitespace", "Statement$105"
-    ],
-    "Statement$98": [
-      1, "whitespace", "Statement$106"
-    ],
-    "Statement$99": [
-      1, "whitespace", "Statement$107"
-    ],
-    "Statement$100": [
-      1, "Type", "Statement$108"
-    ],
-    "Statement$101": [
-      1, "whitespace", "Statement$109"
-    ],
-    "Statement$102": [
-      1, "CommaSep_3", "Statement$110"
-    ],
-    "Statement$103": [
-      1, "whitespace", "Statement$111"
-    ],
-    "Statement$104": [
-      1, "whitespace", "Statement$112"
-    ],
-    "Statement$105": [
-      1, "DottedName", "Statement$58"
-    ],
-    "Statement$106": [
-      1, "Type", "Statement$58"
-    ],
-    "Statement$107": [
-      1, "Type", "Statement$58"
-    ],
-    "Statement$108": [
-      1, "whitespace", "Statement$113"
-    ],
-    "Statement$109": [
-      3, "operator", "...", "Statement$114"
-    ],
-    "Statement$110": [
-      1, "whitespace", "Statement$115"
-    ],
-    "Statement$111": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$58"
-    ],
-    "Statement$112": [
-      "*", "Statement$116"
-    ],
-    "Statement$113": [
-      "=", "Statement$117",
-      0, "Statement$58"
-    ],
-    "Statement$114": [
-      1, "whitespace", "Statement$118"
-    ],
-    "Statement$115": [
-      ">", "Statement$58"
-    ],
-    "Statement$116": [
-      1, "whitespace", "Statement$119"
-    ],
-    "Statement$117": [
-      1, "whitespace", "Statement$120"
-    ],
-    "Statement$118": [
-      ")", "Statement$58"
-    ],
-    "Statement$119": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "Statement$121",
-      0, "Statement$58"
-    ],
-    "Statement$120": [
-      3, "keyword", /^property(?![a-zA-Z0-9_])/, "Statement$122"
-    ],
-    "Statement$121": [
-      1, "whitespace", "Statement$123"
-    ],
-    "Statement$122": [
-      1, "whitespace", "Statement$124"
-    ],
-    "Statement$123": [
-      3, "def", /^[a-zA-Z_][a-zA-Z0-9_]*/, "Statement$58"
-    ],
-    "Statement$124": [
-      "(", "Statement$125"
-    ],
-    "Statement$125": [
-      1, "whitespace", "Statement$126"
-    ],
-    "Statement$126": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$127"
-    ],
-    "Statement$127": [
-      1, "whitespace", "Statement$128"
-    ],
-    "Statement$128": [
-      ",", "Statement$129",
-      0, "Statement$130"
-    ],
-    "Statement$129": [
-      1, "whitespace", "Statement$131"
-    ],
-    "Statement$130": [
-      1, "whitespace", "Statement$132"
-    ],
-    "Statement$131": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Statement$130"
-    ],
-    "Statement$132": [
-      ")", "Statement$58"
-    ],
-    "_lookahead": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "_lookahead$1"
-    ],
-    "_lookahead$1": [
-      1, "whitespace", "_lookahead$2"
-    ],
-    "_lookahead$2": [
-      1, "DottedName", -1,
-      2, "qstring", "_lookahead$3", {"name":"qstring","token":"string"}
-    ],
-    "_lookahead$3": [
-      1, "whitespace", "_lookahead$4"
-    ],
-    "_lookahead$4": [
-      3, "keyword", /^import(?![a-zA-Z0-9_])/, -1
-    ],
-    "InterfaceStatement": [
-      3, "keyword", /^interface(?![a-zA-Z0-9_])/, "InterfaceStatement$1"
-    ],
-    "InterfaceStatement$1": [
-      1, "whitespace", "InterfaceStatement$2"
-    ],
-    "InterfaceStatement$2": [
-      3, "def", /^[a-zA-Z_][a-zA-Z0-9_]*/, "InterfaceStatement$3"
-    ],
-    "InterfaceStatement$3": [
-      1, "whitespace", "InterfaceStatement$4"
-    ],
-    "InterfaceStatement$4": [
-      "<", "InterfaceStatement$5"
-    ],
-    "InterfaceStatement$5": [
-      1, "whitespace", "InterfaceStatement$6"
-    ],
-    "InterfaceStatement$6": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "InterfaceStatement$7"
-    ],
-    "InterfaceStatement$7": [
-      1, "whitespace", "InterfaceStatement$8"
-    ],
-    "InterfaceStatement$8": [
-      ",", "InterfaceStatement$9",
-      ">", "InterfaceStatement$12"
-    ],
-    "InterfaceStatement$9": [
-      1, "whitespace", "InterfaceStatement$10"
-    ],
-    "InterfaceStatement$10": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "InterfaceStatement$11"
-    ],
-    "InterfaceStatement$11": [
-      1, "whitespace", "InterfaceStatement$8"
-    ],
-    "InterfaceStatement$12": [
-      1, "whitespace", "InterfaceStatement$13"
-    ],
-    "InterfaceStatement$13": [
-      ":", "InterfaceStatement$14"
-    ],
-    "InterfaceStatement$14": [
-      1, "whitespace", "InterfaceStatement$15"
-    ],
-    "InterfaceStatement$15": [
-      1, "indentedBody", -1
-    ],
-    "_lookahead_1": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "_lookahead_1$1"
-    ],
-    "_lookahead_1$1": [
-      1, "whitespace", "_lookahead_1$2"
-    ],
-    "_lookahead_1$2": [
-      2, "qstring", -1, {"name":"qstring","token":"string"}
-    ],
-    "_lookahead_2": [
-      3, "keyword", /^from(?![a-zA-Z0-9_])/, "_lookahead_2$1"
-    ],
-    "_lookahead_2$1": [
-      1, "whitespace", "_lookahead_2$2"
-    ],
-    "_lookahead_2$2": [
-      1, "DottedName", -1,
-      2, "qstring", "_lookahead_2$3", {"name":"qstring","token":"string"}
-    ],
-    "_lookahead_2$3": [
-      1, "whitespace", "_lookahead_2$4"
-    ],
-    "_lookahead_2$4": [
-      ":", -1
-    ],
-    "_lookahead_3": [
-      1, "cname", "_lookahead_3$1"
-    ],
-    "_lookahead_3$1": [
-      1, "whitespace", "_lookahead_3$2"
-    ],
-    "_lookahead_3$2": [
-      ":", -1
-    ],
-    "Decorator": [
-      "@", "Decorator$1"
-    ],
-    "Decorator$1": [
-      1, "whitespace", "Decorator$2"
-    ],
-    "Decorator$2": [
-      1, "DottedName", -1
-    ],
-    "qstring": [
-      "'''", "qstring$1",
-      "\"\"\"", "qstring$3",
-      "'", "qstring$5",
-      "\"", "qstring$7"
-    ],
-    "qstring$1": [
-      "\\", "qstring$2",
-      [0, /^(?!\'\'\')/, /^[^]/], "qstring$1",
-      "'''", -1
-    ],
-    "qstring$2": [
-      /^[^]/, "qstring$1"
-    ],
-    "qstring$3": [
-      "\\", "qstring$4",
-      [0, /^(?!\"\"\")/, /^[^]/], "qstring$3",
-      "\"\"\"", -1
-    ],
-    "qstring$4": [
-      /^[^]/, "qstring$3"
-    ],
-    "qstring$5": [
-      "\\", "qstring$6",
-      /^(?!\')./, "qstring$5",
-      "'", -1
-    ],
-    "qstring$6": [
-      /^[^]/, "qstring$5"
-    ],
-    "qstring$7": [
-      "\\", "qstring$8",
-      /^(?!\")./, "qstring$7",
-      "\"", -1
-    ],
-    "qstring$8": [
-      /^[^]/, "qstring$7"
-    ],
-    "indentedBody": [
-      "\n", "indentedBody$1"
-    ],
-    "indentedBody$1": [
-      /^[ \t]/, "indentedBody$1",
-      3, "comment", /^\#.*/, "indentedBody$1",
-      "\n", "indentedBody$1",
-      [7, "stillIndented"], "indentedBody$2"
-    ],
-    "indentedBody$2": [
-      2, "Statement", "indentedBody$3", {"name":"Statement"}
-    ],
-    "indentedBody$3": [
-      /^[ \t]/, "indentedBody$3",
-      3, "comment", /^\#.*/, "indentedBody$3",
-      "\n", "indentedBody$3",
-      0, "indentedBody$4"
-    ],
-    "indentedBody$4": [
-      0, "indentedBody$5",
-      0, -1
-    ],
-    "indentedBody$5": [
-      [7, "stillIndented"], "indentedBody$2"
-    ],
-    "cname": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "cname$1",
-      0, "cname$3"
-    ],
-    "cname$1": [
-      1, "whitespace", "cname$2"
-    ],
-    "cname$2": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "cname$3"
-    ],
-    "cname$3": [
-      1, "whitespace", "cname$4"
-    ],
-    "cname$4": [
-      3, "def", /^[a-zA-Z_][a-zA-Z0-9_]*/, -1
-    ],
-    "Params": [
-      "(", "Params$1"
-    ],
-    "Params$1": [
-      1, "whitespace", "Params$2"
-    ],
-    "Params$2": [
-      1, "CommaSep", "Params$3"
-    ],
-    "Params$3": [
-      1, "whitespace", "Params$4"
-    ],
-    "Params$4": [
-      ")", -1
-    ],
-    "Type": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "Type$1",
-      0, "Type$3"
-    ],
-    "Type$1": [
-      1, "whitespace", "Type$2"
-    ],
-    "Type$2": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "Type$3"
-    ],
-    "Type$3": [
-      1, "whitespace", "Type$4"
-    ],
-    "Type$4": [
-      3, "keyword", /^lambda(?![a-zA-Z0-9_])/, "Type$5",
-      0, "Type$5",
-      1, "DottedName", "Type$6"
-    ],
-    "Type$5": [
-      1, "whitespace", "Type$7"
-    ],
-    "Type$6": [
-      1, "whitespace", "Type$8"
-    ],
-    "Type$7": [
-      2, "Params", "Type$9", {"name":"Params"}
-    ],
-    "Type$8": [
-      "<", "Type$10",
-      0, -1
-    ],
-    "Type$9": [
-      1, "whitespace", "Type$11"
-    ],
-    "Type$10": [
-      1, "whitespace", "Type$12"
-    ],
-    "Type$11": [
-      "->", "Type$13"
-    ],
-    "Type$12": [
-      1, "CommaSep_1", "Type$14"
-    ],
-    "Type$13": [
-      1, "whitespace", "Type$15"
-    ],
-    "Type$14": [
-      1, "whitespace", "Type$16"
-    ],
-    "Type$15": [
-      3, "atom", /^None(?![a-zA-Z0-9_])/, -1,
-      1, "Type", -1,
-      2, "Params", -1, {"name":"Params"}
-    ],
-    "Type$16": [
-      ">", -1
-    ],
-    "Bases": [
-      "(", "Bases$1"
-    ],
-    "Bases$1": [
-      1, "whitespace", "Bases$2"
-    ],
-    "Bases$2": [
-      1, "CommaSep_2", "Bases$3"
-    ],
-    "Bases$3": [
-      1, "whitespace", "Bases$4"
-    ],
-    "Bases$4": [
-      ")", -1
-    ],
-    "d_1": [
-      1, "cname", -1
-    ],
-    "_lookahead_4": [
-      ":", -1,
-      3, "keyword", /^import(?![a-zA-Z0-9_])/, -1
-    ],
-    "DottedName": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "DottedName$1"
-    ],
-    "DottedName$1": [
-      1, "whitespace", "DottedName$2"
-    ],
-    "DottedName$2": [
-      ".", "DottedName$3",
-      0, -1
-    ],
-    "DottedName$3": [
-      1, "whitespace", "DottedName$4"
-    ],
-    "DottedName$4": [
-      /^[a-zA-Z_][a-zA-Z0-9_]*/, "DottedName$5"
-    ],
-    "DottedName$5": [
-      1, "whitespace", "DottedName$2"
-    ],
-    "CommaSep_3": [
-      1, "DottedName", "CommaSep_3$1",
-      0, -1
-    ],
-    "CommaSep_3$1": [
-      1, "whitespace", "CommaSep_3$2"
-    ],
-    "CommaSep_3$2": [
-      ",", "CommaSep_3$3",
-      0, -1
-    ],
-    "CommaSep_3$3": [
-      1, "whitespace", "CommaSep_3$4"
-    ],
-    "CommaSep_3$4": [
-      1, "DottedName", "CommaSep_3$5",
-      0, "CommaSep_3$5"
-    ],
-    "CommaSep_3$5": [
-      1, "whitespace", "CommaSep_3$2"
-    ],
-    "CommaSep": [
-      3, "atom", /^(?:self|cls)(?![a-zA-Z0-9_])/, "CommaSep$1",
-      1, "ParamDef", "CommaSep$1",
-      0, -1
-    ],
-    "CommaSep$1": [
-      1, "whitespace", "CommaSep$2"
-    ],
-    "CommaSep$2": [
-      ",", "CommaSep$3",
-      0, -1
-    ],
-    "CommaSep$3": [
-      1, "whitespace", "CommaSep$4"
-    ],
-    "CommaSep$4": [
-      3, "atom", /^(?:self|cls)(?![a-zA-Z0-9_])/, "CommaSep$5",
-      1, "ParamDef", "CommaSep$5",
-      0, "CommaSep$5"
-    ],
-    "CommaSep$5": [
-      1, "whitespace", "CommaSep$2"
-    ],
-    "CommaSep_1": [
-      1, "Type", "CommaSep_1$1",
-      0, -1
-    ],
-    "CommaSep_1$1": [
-      1, "whitespace", "CommaSep_1$2"
-    ],
-    "CommaSep_1$2": [
-      ",", "CommaSep_1$3",
-      0, -1
-    ],
-    "CommaSep_1$3": [
-      1, "whitespace", "CommaSep_1$4"
-    ],
-    "CommaSep_1$4": [
-      1, "Type", "CommaSep_1$5",
-      0, "CommaSep_1$5"
-    ],
-    "CommaSep_1$5": [
-      1, "whitespace", "CommaSep_1$2"
-    ],
-    "CommaSep_2": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "CommaSep_2$1",
-      0, "CommaSep_2$2",
-      0, -1
-    ],
-    "CommaSep_2$1": [
-      1, "whitespace", "CommaSep_2$3"
-    ],
-    "CommaSep_2$2": [
-      1, "whitespace", "CommaSep_2$4"
-    ],
-    "CommaSep_2$3": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "CommaSep_2$2"
-    ],
-    "CommaSep_2$4": [
-      1, "DottedName", "CommaSep_2$5"
-    ],
-    "CommaSep_2$5": [
-      1, "whitespace", "CommaSep_2$6"
-    ],
-    "CommaSep_2$6": [
-      ",", "CommaSep_2$7",
-      0, -1
-    ],
-    "CommaSep_2$7": [
-      1, "whitespace", "CommaSep_2$8"
-    ],
-    "CommaSep_2$8": [
-      3, "string", /^\`(?:(?!\`).)*\`/, "CommaSep_2$9",
-      0, "CommaSep_2$10",
-      0, "CommaSep_2$11"
-    ],
-    "CommaSep_2$9": [
-      1, "whitespace", "CommaSep_2$12"
-    ],
-    "CommaSep_2$10": [
-      1, "whitespace", "CommaSep_2$13"
-    ],
-    "CommaSep_2$11": [
-      1, "whitespace", "CommaSep_2$6"
-    ],
-    "CommaSep_2$12": [
-      3, "keyword", /^as(?![a-zA-Z0-9_])/, "CommaSep_2$10"
-    ],
-    "CommaSep_2$13": [
-      1, "DottedName", "CommaSep_2$11"
-    ],
-    "ParamDef": [
-      3, "variable-2", /^[a-zA-Z_][a-zA-Z0-9_]*/, "ParamDef$1"
-    ],
-    "ParamDef$1": [
-      1, "whitespace", "ParamDef$2"
-    ],
-    "ParamDef$2": [
-      ":", "ParamDef$3",
-      0, -1
-    ],
-    "ParamDef$3": [
-      1, "whitespace", "ParamDef$4"
-    ],
-    "ParamDef$4": [
-      1, "Type", "ParamDef$5"
-    ],
-    "ParamDef$5": [
-      1, "whitespace", "ParamDef$6"
-    ],
-    "ParamDef$6": [
-      "=", "ParamDef$7",
-      0, -1
-    ],
-    "ParamDef$7": [
-      1, "whitespace", "ParamDef$8"
-    ],
-    "ParamDef$8": [
-      3, "keyword", /^default(?![a-zA-Z0-9_])/, -1
-    ]
-  };
-  var start = "_start";
-  var token = "_token";
+  var e = [/^interface(?![a-zA-Z0-9_])/, /^def(?![a-zA-Z0-9_])/, /^class(?![a-zA-Z0-9_])/, /^enum(?![a-zA-Z0-9_])/, /^staticmethods(?![a-zA-Z0-9_])/, /^namespace(?![a-zA-Z0-9_])/, /^capsule(?![a-zA-Z0-9_])/, /^implements(?![a-zA-Z0-9_])/, /^use(?![a-zA-Z0-9_])/, /^type(?![a-zA-Z0-9_])/, /^const(?![a-zA-Z0-9_])/, /^pass(?![a-zA-Z0-9_])/, /^return(?![a-zA-Z0-9_])/, /^from(?![a-zA-Z0-9_])/, /^[a-zA-Z_][a-zA-Z0-9_]*/, /^None(?![a-zA-Z0-9_])/, /^with(?![a-zA-Z0-9_])/, /^\`(?:(?!\`).)*\`/, /^as(?![a-zA-Z0-9_])/, /^import(?![a-zA-Z0-9_])/, /^property(?![a-zA-Z0-9_])/, [7, "stillIndented"], /^lambda(?![a-zA-Z0-9_])/, /^(?:self|cls)(?![a-zA-Z0-9_])/, /^default(?![a-zA-Z0-9_])/];
+  var nodes = [
+    [1, 6, 2],
+    [/^[^]/, 0],
+    [1, 6, 3],
+    ["\n", 4,
+     2, 8, 4, {"name":"Statement"},
+     0, 1],
+    [1, 6, 3],
+    [3, "keyword", e[18], -1,
+     3, "keyword", e[6], -1,
+     3, "keyword", e[2], -1,
+     3, "keyword", e[10], -1,
+     3, "keyword", e[1], -1,
+     3, "keyword", e[24], -1,
+     3, "keyword", e[3], -1,
+     3, "keyword", e[13], -1,
+     3, "keyword", e[7], -1,
+     3, "keyword", e[19], -1,
+     3, "keyword", e[0], -1,
+     3, "keyword", e[22], -1,
+     3, "keyword", e[5], -1,
+     3, "keyword", e[11], -1,
+     3, "keyword", e[20], -1,
+     3, "keyword", e[12], -1,
+     3, "keyword", e[4], -1,
+     3, "keyword", e[9], -1,
+     3, "keyword", e[8], -1,
+     3, "keyword", e[16], -1,
+     3, "atom", e[15], -1,
+     3, "atom", e[23], -1,
+     3, "comment", /^\#.*/, -1,
+     /^[^]/, -1],
+    [/^[ \t]/, 6,
+     3, "comment", /^\#.*/, 6,
+     [0, /^(?=\n)/, [7, "maySkipNewline"]], 7,
+     0, -1],
+    ["\n", 6],
+    [[6, 153], 9,
+     3, "keyword", e[0], 16,
+     3, "keyword", e[1], 24,
+     3, "keyword", e[2], 36,
+     3, "keyword", e[3], 44,
+     3, "keyword", e[0], 52,
+     3, "keyword", e[4], 60,
+     3, "keyword", e[5], 68,
+     3, "keyword", e[6], 74,
+     3, "keyword", e[7], 75,
+     [6, 158], 76,
+     [6, 161], 77,
+     3, "keyword", e[8], 78,
+     3, "keyword", e[9], 79,
+     3, "keyword", e[10], 80,
+     [5, 166], 81,
+     2, 169, 82, {"name":"Decorator","token":"meta"},
+     3, "string", e[17], 83,
+     3, "keyword", e[11], 82,
+     2, 172, 84, {"name":"qstring","token":"string"},
+     3, "keyword", e[12], 85,
+     e[14], 86],
+    [3, "keyword", e[13], 10],
+    [1, 6, 11],
+    [2, 172, 12, {"name":"qstring","token":"string"}],
+    [1, 6, 13],
+    [":", 14],
+    [1, 6, 15],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 17],
+    [3, "def", e[14], 18],
+    [1, 6, 19],
+    [2, 187, 20, {"name":"TypeParams"}],
+    [1, 6, 21],
+    [":", 22],
+    [1, 6, 23],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 25],
+    [1, 192, 26],
+    [1, 6, 27],
+    [2, 197, 28, {"name":"Params"}],
+    [1, 6, 29],
+    ["->", 30,
+     0, -1],
+    [1, 6, 31],
+    [3, "atom", e[15], 32,
+     1, 202, 32,
+     2, 197, 32, {"name":"Params"}],
+    [1, 6, 33],
+    [":", 34,
+     0, -1],
+    [1, 6, 35],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 37],
+    [1, 192, 38],
+    [1, 6, 39],
+    [2, 216, 40, {"name":"Bases"},
+     0, 40],
+    [1, 6, 41],
+    [":", 42],
+    [1, 6, 43],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 45],
+    [1, 192, 46],
+    [1, 6, 47],
+    [3, "keyword", e[16], 48,
+     0, -1],
+    [1, 6, 49],
+    [":", 50],
+    [1, 6, 51],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 53],
+    [3, "def", e[14], 54],
+    [1, 6, 55],
+    [2, 187, 56, {"name":"TypeParams"}],
+    [1, 6, 57],
+    [":", 58],
+    [1, 6, 59],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 61],
+    [3, "keyword", e[13], 62],
+    [1, 6, 63],
+    [3, "string", e[17], 64],
+    [1, 6, 65],
+    [":", 66],
+    [1, 6, 67],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 69],
+    [3, "string", e[17], 70],
+    [1, 6, 71],
+    [":", 72],
+    [1, 6, 73],
+    [2, 181, -1, {"name":"indentedBody"}],
+    [1, 6, 87],
+    [1, 6, 88],
+    [3, "keyword", e[13], 89],
+    [3, "keyword", e[13], 90],
+    [1, 6, 91],
+    [1, 6, 92],
+    [1, 6, 93],
+    [1, 192, 94],
+    [1, 6, 95],
+    [1, 6, 96],
+    [1, 6, 97],
+    [1, 6, 98],
+    [1, 6, 99],
+    [1, 192, 82],
+    [e[14], 100],
+    [1, 6, 101],
+    [1, 6, 102],
+    [3, "string", e[17], 103],
+    [3, "def", e[14], 104],
+    [2, 221, 105, {"name":"d","token":"def"}],
+    [1, 6, 106],
+    ["\n", -1],
+    [3, "keyword", e[18], 107],
+    [[6, 222], 82],
+    [e[14], 108],
+    [/^(?!\:)/, 82],
+    [1, 6, 109],
+    [1, 223, 110],
+    [2, 172, 111, {"name":"qstring","token":"string"}],
+    [1, 6, 112],
+    [1, 6, 113],
+    [1, 6, 114],
+    [":", 115],
+    [1, 6, 116],
+    [1, 6, 117],
+    [2, 229, 82, {"name":"QualifiedTypes"}],
+    [1, 6, 118],
+    [1, 6, 119],
+    [3, "keyword", e[18], 120],
+    ["=", 121],
+    [":", 122],
+    [1, 6, 123],
+    [1, 223, 82],
+    ["(", 124],
+    [3, "keyword", e[19], 125],
+    [3, "keyword", e[19], 126],
+    [1, 6, 127],
+    [1, 6, 128],
+    [1, 6, 129],
+    [1, 202, 130],
+    [1, 6, 131],
+    [1, 6, 132],
+    [1, 6, 133],
+    [1, 223, 82],
+    [1, 202, 82],
+    [1, 202, 82],
+    [1, 6, 134],
+    [3, "operator", "...", 135],
+    [e[14], 82],
+    ["*", 136],
+    ["=", 137,
+     0, 82],
+    [1, 6, 138],
+    [1, 6, 139],
+    [1, 6, 140],
+    [")", 82],
+    [3, "keyword", e[18], 141,
+     0, 82],
+    [3, "keyword", e[20], 142],
+    [1, 6, 143],
+    [1, 6, 144],
+    [3, "def", e[14], 82],
+    ["(", 145],
+    [1, 6, 146],
+    [3, "string", e[17], 147],
+    [1, 6, 148],
+    [",", 149,
+     0, 150],
+    [1, 6, 151],
+    [1, 6, 152],
+    [3, "string", e[17], 150],
+    [")", 82],
+    [3, "keyword", e[13], 154],
+    [1, 6, 155],
+    [1, 223, -1,
+     2, 172, 156, {"name":"qstring","token":"string"}],
+    [1, 6, 157],
+    [3, "keyword", e[19], -1],
+    [3, "keyword", e[13], 159],
+    [1, 6, 160],
+    [2, 172, -1, {"name":"qstring","token":"string"}],
+    [3, "keyword", e[13], 162],
+    [1, 6, 163],
+    [1, 223, -1,
+     2, 172, 164, {"name":"qstring","token":"string"}],
+    [1, 6, 165],
+    [":", -1],
+    [1, 192, 167],
+    [1, 6, 168],
+    [":", -1],
+    ["@", 170],
+    [1, 6, 171],
+    [1, 223, -1],
+    ["'''", 173,
+     "\"\"\"", 175,
+     "'", 177,
+     "\"", 179],
+    ["\\", 174,
+     [0, /^(?!\'\'\')/, /^[^]/], 173,
+     "'''", -1],
+    [/^[^]/, 173],
+    ["\\", 176,
+     [0, /^(?!\"\"\")/, /^[^]/], 175,
+     "\"\"\"", -1],
+    [/^[^]/, 175],
+    ["\\", 178,
+     /^(?!\')./, 177,
+     "'", -1],
+    [/^[^]/, 177],
+    ["\\", 180,
+     /^(?!\")./, 179,
+     "\"", -1],
+    [/^[^]/, 179],
+    ["\n", 182],
+    [/^[ \t]/, 182,
+     3, "comment", /^\#.*/, 182,
+     "\n", 182,
+     e[21], 183],
+    [2, 8, 184, {"name":"Statement"}],
+    [/^[ \t]/, 184,
+     3, "comment", /^\#.*/, 184,
+     "\n", 184,
+     0, 185],
+    [0, 186,
+     0, -1],
+    [e[21], 183],
+    ["<", 188],
+    [1, 6, 189],
+    [1, 234, 190],
+    [1, 6, 191],
+    [">", -1],
+    [3, "string", e[17], 193,
+     0, 195],
+    [1, 6, 194],
+    [3, "keyword", e[18], 195],
+    [1, 6, 196],
+    [3, "def", e[14], -1],
+    ["(", 198],
+    [1, 6, 199],
+    [1, 240, 200],
+    [1, 6, 201],
+    [")", -1],
+    [3, "string", e[17], 203,
+     0, 205],
+    [1, 6, 204],
+    [3, "keyword", e[18], 205],
+    [1, 6, 206],
+    [[6, 246], 207,
+     3, "keyword", e[22], 208,
+     0, 208],
+    [1, 223, 209],
+    [1, 6, 210],
+    [1, 6, 211],
+    [2, 197, 212, {"name":"Params"}],
+    [2, 247, -1, {"name":"Types"},
+     0, -1],
+    [1, 6, 213],
+    ["->", 214],
+    [1, 6, 215],
+    [3, "atom", e[15], -1,
+     1, 202, -1,
+     2, 197, -1, {"name":"Params"}],
+    ["(", 217],
+    [1, 6, 218],
+    [1, 252, 219],
+    [1, 6, 220],
+    [")", -1],
+    [1, 192, -1],
+    [":", -1,
+     3, "keyword", e[19], -1],
+    [e[14], 224],
+    [1, 6, 225],
+    [".", 226,
+     0, -1],
+    [1, 6, 227],
+    [e[14], 228],
+    [1, 6, 225],
+    ["<", 230],
+    [1, 6, 231],
+    [1, 266, 232],
+    [1, 6, 233],
+    [">", -1],
+    [e[14], 235,
+     0, -1],
+    [1, 6, 236],
+    [",", 237,
+     /^\,?/, -1],
+    [1, 6, 238],
+    [/^(?:[a-zA-Z_][a-zA-Z0-9_]*)?/, 239],
+    [1, 6, 236],
+    [3, "atom", e[23], 241,
+     1, 272, 241,
+     0, -1],
+    [1, 6, 242],
+    [",", 243,
+     /^\,?/, -1],
+    [1, 6, 244],
+    [3, "atom", e[23], 245,
+     1, 272, 245,
+     0, 245],
+    [1, 6, 242],
+    [3, "keyword", e[22], -1,
+     "(", -1],
+    ["<", 248],
+    [1, 6, 249],
+    [1, 281, 250],
+    [1, 6, 251],
+    [">", -1],
+    [3, "string", e[17], 253,
+     0, 254,
+     0, -1],
+    [1, 6, 255],
+    [1, 6, 256],
+    [3, "keyword", e[18], 254],
+    [1, 223, 257],
+    [1, 6, 258],
+    [",", 259,
+     /^\,?/, -1],
+    [1, 6, 260],
+    [3, "string", e[17], 261,
+     0, 262,
+     0, 263],
+    [1, 6, 264],
+    [1, 6, 265],
+    [1, 6, 258],
+    [3, "keyword", e[18], 262],
+    [1, 223, 263],
+    [1, 223, 267,
+     0, -1],
+    [1, 6, 268],
+    [",", 269,
+     /^\,?/, -1],
+    [1, 6, 270],
+    [1, 223, 271,
+     0, 271],
+    [1, 6, 268],
+    [3, "variable-2", e[14], 273],
+    [1, 6, 274],
+    [":", 275,
+     0, -1],
+    [1, 6, 276],
+    [1, 202, 277],
+    [1, 6, 278],
+    ["=", 279,
+     0, -1],
+    [1, 6, 280],
+    [3, "keyword", e[24], -1],
+    [1, 202, 282,
+     0, -1],
+    [1, 6, 283],
+    [",", 284,
+     /^\,?/, -1],
+    [1, 6, 285],
+    [1, 202, 286,
+     0, 286],
+    [1, 6, 283]
+  ];
+  var start = 0;
+  var token = 5;
 
   var grammar = /*#__PURE__*/Object.freeze({
     nodes: nodes,
@@ -966,7 +440,8 @@
 
   var scopes = ["FuncDef", "ClassDef"];
 
-  var allowNewline = ["Bases", "Params"];
+  var allowNewline = [
+      "Bases", "Params", "Types", "QualifiedTypes", "TypeParams" ];
 
   function maySkipNewline(_line, _pos, cx) {
     return cx && allowNewline.indexOf(cx.name) > -1
@@ -988,6 +463,42 @@
     return cx && countIndent(line, pos) > countIndent(cx.startLine, cx.startPos)
   }
 
+  function aligned(cx) {
+    return !/^\s*((#.*)?$)/.test(cx.startLine.slice(cx.startPos + 1))
+  }
+
+  var bracketed = {
+    Bases: ")", Params: ")",
+    Types: ">", QualifiedTypes: ">", TypeParams: ">",
+  };
+
+
+  function findIndent(cx, textAfter, curLine, config) {
+    if (!cx) { return 0 }
+    if (cx.name == "string") { return CodeMirror.Pass }
+
+    var brack = bracketed[cx.name];
+    if (brack) {
+      if (curLine != cx.startLine && aligned(cx)) {
+        return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + 1
+      }
+
+      var closed = textAfter && textAfter.charAt(0) == brack;
+      var flat = closed || curLine == cx.startLine;
+      return findIndent(cx.parent, closed ? null : textAfter, cx.startLine, config) + (flat ? 0 : 2 * config.indentUnit)
+    } else if (cx.name == "indentedBody") {
+      for (;; cx = cx.parent) {
+        console.log(2);
+        if (!cx) { return config.indentUnit }
+        if (cx.name == "Statement") { return CodeMirror.countColumn(cx.startLine, null, config.tabSize) + config.indentUnit }
+      }
+    } else {
+      return findIndent(cx.parent, textAfter, curLine, config) +
+        (cx.name == "Statement" && curLine != cx.startLine ? 2 * config.indentUnit : 0)
+    }
+  }
+
+
   var ClifMode = /*@__PURE__*/(function (superclass) {
     function ClifMode(conf) {
       superclass.call(this, grammar, {
@@ -1005,8 +516,7 @@
     };
 
     ClifMode.prototype.indent = function indent (state, textAfter, line) {
-      // TODO(slebedev): Not currently supported.
-      return CodeMirror.Pass
+      return findIndent(state.contextAt(line, line.length - textAfter.length), textAfter, null, this.conf)
     };
 
     return ClifMode;
@@ -1015,7 +525,9 @@
   ClifMode.prototype.electricInput = /^\s*\(\)<>$/;
   ClifMode.prototype.closeBrackets = {triples: "'\"", pairs: "()<>''\"\"``",};
   ClifMode.prototype.lineComment = "#";
+  ClifMode.prototype.fold = "indent";
 
   CodeMirror.defineMode("google-clif", function (conf) { return new ClifMode(conf); });
+  CodeMirror.defineMIME("text/x-clif", {name: "google-clif"});
 
 })));

--- a/src/clif.grammar
+++ b/src/clif.grammar
@@ -47,8 +47,9 @@ skip whitespace {
   NamespaceStatement { namespace astring ":" indentedBody }
 
   InterfaceStatement {
-    interface d(name) "<" name ("," name)* ">" ":" indentedBody
+    interface d(name) TypeParams ":" indentedBody
   }
+  context TypeParams { "<" CommaSep(name) ">" }
 
   StaticMethodsStatement {
     staticmethods from astring ":" indentedBody
@@ -66,13 +67,15 @@ skip whitespace {
   ClassDef { class cname Bases? ":" indentedBody }
   context Bases { "(" CommaSep(tname) ")" }
 
-  ImplementsDef { implements name "<" CommaSep(DottedName) ">" }
+  ImplementsDef { implements name QualifiedTypes }
+  context QualifiedTypes { "<" CommaSep(DottedName) ">" }
 
   FuncDef { def cname Params (Returns (":" indentedBody)?)? }
 
   Type {
-    rename? (lambda? Params Returns | DottedName ("<" CommaSep(Type) ">")?)
+    rename? (!(lambda | "(") DottedName Types? | lambda? Params Returns)
   }
+  context Types { "<" CommaSep(Type) ">" }
 
   ParamDef { locald(name) (":" Type ("=" default)?)? }
   context Params { "(" CommaSep(receiver | ParamDef) ")" }
@@ -85,7 +88,7 @@ skip whitespace {
   rename { astring as }
   cname { rename? d(name) }
   tname { rename? DottedName }
-  CommaSep(expr) { (expr ("," expr?)*)? }
+  CommaSep(expr) { (expr ("," expr?)* ","?)? }
 }
 
 tokens {
@@ -131,7 +134,7 @@ d(word)="def" { word }
 locald(word)="variable-2" { word }
 op(expr)="operator" { expr }
 
-indentedBody {
+context indentedBody {
   "\n" (whitespaceSimple | "\n")* (&stillIndented Statement (whitespaceSimple | "\n")*)+
 }
 

--- a/src/clif.js
+++ b/src/clif.js
@@ -5,7 +5,9 @@ import {markLocals} from "./locals"
 
 const scopes = ["FuncDef", "ClassDef"]
 
-const allowNewline = ["Bases", "Params"]
+const allowNewline = [
+    "Bases", "Params", "Types", "QualifiedTypes", "TypeParams",
+]
 
 function maySkipNewline(_line, _pos, cx) {
   return cx && allowNewline.indexOf(cx.name) > -1
@@ -27,6 +29,41 @@ function stillIndented(line, pos, cx) {
   return cx && countIndent(line, pos) > countIndent(cx.startLine, cx.startPos)
 }
 
+function aligned(cx) {
+  return !/^\s*((#.*)?$)/.test(cx.startLine.slice(cx.startPos + 1))
+}
+
+const bracketed = {
+  Bases: ")", Params: ")",
+  Types: ">", QualifiedTypes: ">", TypeParams: ">",
+}
+
+
+function findIndent(cx, textAfter, curLine, config) {
+  if (!cx) return 0
+  if (cx.name == "string") return CodeMirror.Pass
+
+  let brack = bracketed[cx.name]
+  if (brack) {
+    if (curLine != cx.startLine && aligned(cx)) {
+      return CodeMirror.countColumn(cx.startLine, cx.startPos, config.tabSize) + 1
+    }
+
+    let closed = textAfter && textAfter.charAt(0) == brack
+    let flat = closed || curLine == cx.startLine
+    return findIndent(cx.parent, closed ? null : textAfter, cx.startLine, config) + (flat ? 0 : 2 * config.indentUnit)
+  } else if (cx.name == "indentedBody") {
+    for (;; cx = cx.parent) {
+      if (!cx) return config.indentUnit
+      if (cx.name == "Statement") return CodeMirror.countColumn(cx.startLine, null, config.tabSize) + config.indentUnit
+    }
+  } else {
+    return findIndent(cx.parent, textAfter, curLine, config) +
+      (cx.name == "Statement" && curLine != cx.startLine ? 2 * config.indentUnit : 0)
+  }
+}
+
+
 class ClifMode extends CodeMirror.GrammarMode {
   constructor(conf) {
     super(grammar, {
@@ -40,13 +77,14 @@ class ClifMode extends CodeMirror.GrammarMode {
   }
 
   indent(state, textAfter, line) {
-    // TODO(slebedev): Not currently supported.
-    return CodeMirror.Pass
+    return findIndent(state.contextAt(line, line.length - textAfter.length), textAfter, null, this.conf)
   }
 }
 
 ClifMode.prototype.electricInput = /^\s*\(\)<>$/
 ClifMode.prototype.closeBrackets = {triples: "'\"", pairs: "()<>''\"\"``",}
 ClifMode.prototype.lineComment = "#"
+ClifMode.prototype.fold = "indent"
 
 CodeMirror.defineMode("google-clif", conf => new ClifMode(conf))
+CodeMirror.defineMIME("text/x-clif", {name: "google-clif"})

--- a/test/clif/grammar.clif
+++ b/test/clif/grammar.clif
@@ -42,4 +42,7 @@ defx
 
 [comment # Compound statements]
 [keyword from] [string "baz.h"]:
-[keyword namespace] [string `std::boo`]:
+  [keyword namespace] [string `std::boo`]:
+    [keyword def] [def f]()
+    [keyword interface] [def A] <T>:
+      [def x]: int

--- a/test/clif/indent.clif
+++ b/test/clif/indent.clif
@@ -1,0 +1,35 @@
+# test: indent_only
+
+def f(
+    x: int)
+
+def f(x: int,
+      y: int)
+
+def f(x: int,
+      y: int) -> (x: int,
+                  ) -> int
+
+interface Foo<A,
+              B>:
+  x: int
+
+class C:
+  def f(self) -> C
+
+  # Comment directly after DEDENT.
+  # TODO(slebedev): This is a known bug which also affects google-python mode.
+  # Shift to the toplevel and the test will fail.
+  def f() -> C
+
+from "foo.h":
+  x: int
+
+  namespace `std::foo`:
+    x: int
+
+    interface Foo<T>:
+      def bar(self) -> T
+
+  def bar(self) -> Foo<bytes>
+  def boo(self)


### PR DESCRIPTION
As with the grammar itself, the majority of the logic has been adopted from the Python mode.

Note that both modes correctly (but annoyingly) ignore comments when computing indentation, e.g. here

```
class A:
  x: int

# Foo bar. <CURSOR>
```

The suggested indentation level will be 2, because according to the spec, comments do not affect indentation. Yet ~any user will expect the suggested indentation level to match that of the comment.