### PR TITLE
[py] Fixed parsing of == within a function call

### DIFF
--- a/src/python.grammar
+++ b/src/python.grammar
@@ -225,7 +225,7 @@ identifier { identifierStart identifierChar* }
 
 declName="def" { identifier }
 typeDeclName="type def" { identifier }
-labelName="meta" { identifier ~(" "* "=") }
+labelName="meta" { identifier ~(" "* "=" !"=") }
 calleeName="variable callee" { identifier ~"(" }
 calleeProp="property callee" { identifier ~"(" }
 propName="property" { identifier }

--- a/test/py/grammar.py
+++ b/test/py/grammar.py
@@ -82,6 +82,8 @@
   [keyword pass]
 
 [callee&variable foo]([meta dir]=[string "a"], [meta file]=[string "b"])
+[callee&variable foo]([variable x] [operator ==] [variable y])
+[callee&variable foo]([meta p]=[variable x] [operator ==] [variable y])
 
 [keyword def] [def testRaise]():
   [variable-2 bar] [operator =] [number 1]


### PR DESCRIPTION
Prior to this change, the parser would unconditionally treat

    f(|x=|...

as a keyword argument, even in

    f(x==y)