### PR TITLE
[py] Allow \n after in in *-comprehensions

### DIFF
--- a/dist/python.js
+++ b/dist/python.js
@@ -2,7 +2,7 @@
   typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('codemirror'), require('codemirror-grammar-mode')) :
   typeof define === 'function' && define.amd ? define(['codemirror', 'codemirror-grammar-mode'], factory) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.CodeMirror));
-}(this, (function (CodeMirror) { 'use strict';
+})(this, (function (CodeMirror) { 'use strict';
 
   function _interopNamespace(e) {
     if (e && e.__esModule) return e;
@@ -13,807 +13,1829 @@
           var d = Object.getOwnPropertyDescriptor(e, k);
           Object.defineProperty(n, k, d.get ? d : {
             enumerable: true,
-            get: function () {
-              return e[k];
-            }
+            get: function () { return e[k]; }
           });
         }
       });
     }
-    n['default'] = e;
+    n["default"] = e;
     return Object.freeze(n);
   }
 
   var CodeMirror__namespace = /*#__PURE__*/_interopNamespace(CodeMirror);
 
-  var e = [/^if(?![a-zA-Z¡-￿_0-9_])/, /^(?:while|elif)(?![a-zA-Z¡-￿_0-9_])/, /^else(?![a-zA-Z¡-￿_0-9_])/, /^(?:try|finally)(?![a-zA-Z¡-￿_0-9_])/, /^for(?![a-zA-Z¡-￿_0-9_])/, /^except(?![a-zA-Z¡-￿_0-9_])/, /^async(?![a-zA-Z¡-￿_0-9_])/, /^print(?![a-zA-Z¡-￿_0-9_])/, /^in(?![a-zA-Z¡-￿_0-9_])/, /^as(?![a-zA-Z¡-￿_0-9_])/, /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, [0, /^(?![\{\}])/, /^[^]/], /^(?![\{\}])./, /^with(?![a-zA-Z¡-￿_0-9_])/, /^def(?![a-zA-Z¡-￿_0-9_])/, /^class(?![a-zA-Z¡-￿_0-9_])/, /^(?:pass|break|continue)(?![a-zA-Z¡-￿_0-9_])/, /^del(?![a-zA-Z¡-￿_0-9_])/, /^(?:return|assert)(?![a-zA-Z¡-￿_0-9_])/, /^raise(?![a-zA-Z¡-￿_0-9_])/, /^import(?![a-zA-Z¡-￿_0-9_])/, /^from(?![a-zA-Z¡-￿_0-9_])/, /^(?:global|nonlocal)(?![a-zA-Z¡-￿_0-9_])/, /^[\*\+\-\~]/, /^(?:not|await)(?![a-zA-Z¡-￿_0-9_])/, /^(?:(?:0b|OB)[01_]+|(?:0o|0O)[0-7_]+|(?:0x|OX)[0-9a-fA-F_]+|(?:[0-9][0-9_]*(?:l|L|\.[0-9_]+)?|\.[0-9_]+)(?:[eE][\+\-]?[0-9_]+)?[jJ]?)/, /^(?:None|True|False)(?![a-zA-Z¡-￿_0-9_])/, /^self(?![a-zA-Z¡-￿_0-9_])/, /^yield(?![a-zA-Z¡-￿_0-9_])/, /^lambda(?![a-zA-Z¡-￿_0-9_])/, /^(?:abs|all|any|bin|bool|bytearray|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__|NotImplemented|Ellipsis|__debug__|ascii|bytes|exec|print)(?![a-zA-Z¡-￿_0-9_])/, /^(?:(?:\^|\&|\||\<\<|\>\>|\+|\-|\*\*?|\@|\/|\%|\/)\=?|\=|\<|\>|\=\=|\>\=|\<\=|\<\>|\!\=|\:\=)/, /^(?:or|and|in|is(?: +not)?|not(?: +in)?)(?![a-zA-Z¡-￿_0-9_])/, /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?=\()/, /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?= *\=(?!\=))/, [0, /^[a-zA-Z¡-￿__]/, /^[a-zA-Z¡-￿_0-9_]*/, [7, "isCompLocal"]], /^(?:\*|\*\*)/];
-  var nodes = [
-    [1, 6, 2],
-    [/^[^]/, 0],
-    [1, 6, 3],
-    ["\n", 4,
-     2, 9, 4, {"name":"Statement"},
-     0, 1],
-    [1, 6, 3],
-    [3, "keyword", e[0], -1,
-     3, "keyword", e[1], -1,
-     3, "keyword", e[2], -1,
-     3, "keyword", e[3], -1,
-     3, "keyword", e[4], -1,
-     3, "keyword", e[8], -1,
-     3, "keyword", e[9], -1,
-     3, "keyword", e[6], -1,
-     3, "keyword", e[14], -1,
-     3, "keyword", e[5], -1,
-     3, "keyword", e[15], -1,
-     3, "keyword", e[13], -1,
-     3, "keyword", e[29], -1,
-     3, "keyword", e[17], -1,
-     3, "keyword", e[28], -1,
-     3, "keyword", e[19], -1,
-     3, "keyword", e[21], -1,
-     3, "keyword", e[20], -1,
-     3, "keyword", e[16], -1,
-     3, "keyword", e[22], -1,
-     3, "keyword", e[18], -1,
-     3, "keyword", e[24], -1,
-     3, "atom", e[26], -1,
-     3, "atom", e[27], -1,
-     3, "keyword", e[32], -1,
-     3, "builtin", e[30], -1,
-     3, "builtin", e[7], -1,
-     3, "operator", e[31], -1,
-     3, "operator", e[23], -1,
-     3, "number", e[25], -1,
-     2, 53, -1, {"name":"string","token":"string"},
-     1, 55, -1,
-     3, "variable", e[10], -1,
-     3, "comment", /^\#.*/, -1,
-     /^[^]/, -1],
-    [/^[ \t]/, 6,
-     3, "comment", /^\#.*/, 6,
-     "\\", 7,
-     [0, /^(?=\n)/, [7, "maySkipNewline"]], 8,
-     0, -1],
-    ["\n", 6],
-    ["\n", 6],
-    [3, "keyword", e[0], 10,
-     3, "keyword", e[1], 10,
-     3, "keyword", e[2], 16,
-     3, "keyword", e[3], 16,
-     3, "keyword", e[4], 20,
-     3, "keyword", e[5], 30,
-     3, "keyword", e[6], 40,
-     1, 67, -1,
-     2, 80, 42, {"name":"Annotation","token":"meta"},
-     3, "builtin", e[7], 46,
-     1, 88, 48],
-    [1, 6, 11],
-    [1, 120, 12],
-    [1, 6, 13],
-    [":", 14],
-    [1, 6, 15],
-    [1, 127, -1],
-    [1, 6, 17],
-    [":", 18],
-    [1, 6, 19],
-    [1, 127, -1],
-    [1, 6, 21],
-    [1, 133, 22],
-    [1, 6, 23],
-    [3, "keyword", e[8], 24],
-    [1, 6, 25],
-    [1, 120, 26],
-    [1, 6, 27],
-    [":", 28],
-    [1, 6, 29],
-    [1, 127, -1],
-    [1, 6, 31],
-    [1, 120, 32,
-     0, 33],
-    [1, 6, 34],
-    [1, 6, 35],
-    [3, "keyword", e[9], 36,
-     0, 33],
-    [":", 37],
-    [1, 6, 38],
-    [1, 6, 39],
-    [3, "def", e[10], 33],
-    [1, 127, -1],
-    [1, 6, 41],
-    [1, 67, -1],
-    [1, 6, 43],
-    [2, 141, 44, {"name":"ArgList"},
-     0, 44],
-    [1, 6, 45],
-    ["\n", -1],
-    [1, 6, 47],
-    [2, 141, -1, {"name":"ArgList"},
-     1, 120, -1],
-    [1, 6, 49],
-    [";", 50,
-     "\n", -1],
-    [1, 6, 51],
-    [1, 88, 52,
-     0, 52],
-    [1, 6, 49],
-    [/^[uUrRbB]+(?=[\'\"])/, 54,
-     1, 146, -1],
-    [1, 146, -1],
-    [3, "string", /^[uUrR]*[fF][uUrR]*(?=[\'\"])/, 56],
-    [3, "string", "'''", 57,
-     3, "string", "\"\"\"", 58,
-     3, "string", "'", 59,
-     3, "string", "\"", 60],
-    [/^(?!\'\'\')/, 61,
-     3, "string", "{{", 57,
-     3, "string", "}}", 57,
-     1, 155, 57,
-     3, "string", "'''", -1],
-    [/^(?!\"\"\")/, 62,
-     3, "string", "{{", 58,
-     3, "string", "}}", 58,
-     1, 155, 58,
-     3, "string", "\"\"\"", -1],
-    [3, "string", "\\", 63,
-     /^(?!\')/, 64,
-     3, "string", "{{", 59,
-     3, "string", "}}", 59,
-     1, 155, 59,
-     3, "string", "'", -1],
-    [3, "string", "\\", 65,
-     /^(?!\")/, 66,
-     3, "string", "{{", 60,
-     3, "string", "}}", 60,
-     1, 155, 60,
-     3, "string", "\"", -1],
-    [3, "string", e[11], 57],
-    [3, "string", e[11], 58],
-    [3, "string", e[11], 59],
-    [3, "string", e[12], 59],
-    [3, "string", e[11], 60],
-    [3, "string", e[12], 60],
-    [3, "keyword", e[13], 68,
-     3, "keyword", e[14], 74,
-     3, "keyword", e[15], 78],
-    [1, 6, 69],
-    [1, 163, 70],
-    [1, 6, 71],
-    [":", 72],
-    [1, 6, 73],
-    [1, 127, -1],
-    [1, 6, 75],
-    [3, "def", e[10], 76],
-    [1, 6, 77],
-    [2, 177, -1, {"name":"FuncDef"}],
-    [1, 6, 79],
-    [2, 186, -1, {"name":"ClassDef"}],
-    ["@", 81],
-    [1, 6, 82],
-    [e[10], 83],
-    [1, 6, 84],
-    [".", 85,
-     0, -1],
-    [1, 6, 86],
-    [e[10], 87],
-    [1, 6, 84],
-    [3, "keyword", e[16], -1,
-     3, "keyword", e[17], 89,
-     3, "keyword", e[18], 91,
-     3, "keyword", e[19], 93,
-     3, "keyword", e[20], 99,
-     3, "keyword", e[21], 101,
-     3, "keyword", e[22], 109,
-     [5, 193], 111,
-     1, 120, -1],
-    [1, 6, 90],
-    [1, 120, -1],
-    [1, 6, 92],
-    [1, 120, -1,
-     0, -1],
-    [1, 6, 94],
-    [1, 120, 95,
-     0, 95],
-    [1, 6, 96],
-    [3, "keyword", e[21], 97,
-     0, -1],
-    [1, 6, 98],
-    [1, 120, -1],
-    [1, 6, 100],
-    [1, 196, -1],
-    [1, 6, 102],
-    [".", 103,
-     [6, 210], 104,
-     3, "keyword", e[20], 105],
-    [1, 6, 102],
-    [1, 120, 106],
-    [1, 6, 107],
-    [1, 6, 108],
-    ["*", -1,
-     2, 211, -1, {"name":"FromImportList"},
-     1, 218, -1],
-    [3, "keyword", e[20], 105],
-    [1, 6, 110],
-    [1, 232, -1],
-    [1, 238, 112],
-    [1, 6, 113],
-    [":", 114,
-     0, 115],
-    [1, 6, 116],
-    [1, 6, 117],
-    [1, 120, 115],
-    [3, "operator", "=", 118,
-     0, -1],
-    [1, 6, 119],
-    [1, 120, -1],
-    [3, "operator", e[23], 121,
-     3, "keyword", e[24], 121,
-     1, 239, 122],
-    [1, 6, 120],
-    [1, 6, 123],
-    [1, 249, 124,
-     3, "keyword", e[8], 125,
-     ",", 125,
-     0, -1],
-    [1, 6, 123],
-    [1, 6, 126],
-    [1, 260, 124],
-    [1, 88, 128,
-     2, 267, -1, {"name":"indentedBody"}],
-    [1, 6, 129],
-    [";", 130,
-     "\n", -1],
-    [1, 6, 131],
-    [1, 88, 132,
-     0, 132],
-    [1, 6, 129],
-    [[5, 273], 134,
-     1, 276, 135],
-    [1, 238, 135],
-    [1, 6, 136],
-    [",", 137,
-     0, -1],
-    [1, 6, 138],
-    [[5, 273], 139,
-     1, 276, 140,
-     0, 140],
-    [1, 238, 140],
-    [1, 6, 136],
-    ["(", 142],
-    [1, 6, 143],
-    [1, 281, 144,
-     0, 144],
-    [1, 6, 145],
-    [")", -1],
-    ["'''", 147,
-     "\"\"\"", 149,
-     "'", 151,
-     "\"", 153],
-    ["\\", 148,
-     [0, /^(?!\'\'\')/, /^[^]/], 147,
-     "'''", -1],
-    [/^[^]/, 147],
-    ["\\", 150,
-     [0, /^(?!\"\"\")/, /^[^]/], 149,
-     "\"\"\"", -1],
-    [/^[^]/, 149],
-    ["\\", 152,
-     /^(?!\')./, 151,
-     "'", -1],
-    [/^[^]/, 151],
-    ["\\", 154,
-     /^(?!\")./, 153,
-     "\"", -1],
-    [/^[^]/, 153],
-    [3, "operator", "{", 156],
-    [1, 120, 157,
-     0, 157],
-    [3, "operator", "=", 158,
-     0, 158],
-    [3, "operator", "!", 159,
-     0, 160],
-    [3, "keyword", /^(?:(?![\:\} \t]).)*/, 160],
-    [3, "operator", ":", 161,
-     0, 162],
-    [3, "string", e[12], 161,
-     1, 155, 161,
-     0, 162],
-    [3, "operator", "}", -1],
-    [1, 260, 164],
-    [1, 6, 165],
-    [3, "keyword", e[9], 166,
-     0, 168],
-    [1, 6, 167],
-    [3, "def", e[10], 168,
-     2, 293, 168, {"name":"ParenPattern"},
-     2, 298, 168, {"name":"BracketPattern"}],
-    [1, 6, 169],
-    [",", 170,
-     0, -1],
-    [1, 6, 171],
-    [1, 260, 172,
-     0, 173],
-    [1, 6, 174],
-    [1, 6, 169],
-    [3, "keyword", e[9], 175,
-     0, 173],
-    [1, 6, 176],
-    [3, "def", e[10], 173,
-     2, 293, 173, {"name":"ParenPattern"},
-     2, 298, 173, {"name":"BracketPattern"}],
-    [2, 303, 178, {"name":"ParamList"}],
-    [1, 6, 179],
-    ["->", 180,
-     0, 182],
-    [1, 6, 181],
-    [1, 120, 182],
-    [1, 6, 183],
-    [":", 184],
-    [1, 6, 185],
-    [1, 127, -1],
-    [3, "type def", e[10], 187],
-    [1, 6, 188],
-    [2, 141, 189, {"name":"ArgList"},
-     0, 189],
-    [1, 6, 190],
-    [":", 191],
-    [1, 6, 192],
-    [1, 127, -1],
-    [1, 238, 194],
-    [1, 6, 195],
-    [/^[\=\:]/, -1],
-    [1, 260, 197],
-    [1, 6, 198],
-    [3, "keyword", e[9], 199,
-     0, 201],
-    [1, 6, 200],
-    [3, "def", e[10], 201],
-    [1, 6, 202],
-    [",", 203,
-     0, -1],
-    [1, 6, 204],
-    [1, 260, 205,
-     0, 206],
-    [1, 6, 207],
-    [1, 6, 202],
-    [3, "keyword", e[9], 208,
-     0, 206],
-    [1, 6, 209],
-    [3, "def", e[10], 206],
-    [3, "keyword", e[20], -1],
-    ["(", 212],
-    [1, 6, 213],
-    [1, 218, 214,
-     0, 214],
-    [1, 6, 215],
-    [/^\,?/, 216],
-    [1, 6, 217],
-    [")", -1],
-    [e[10], 219],
-    [1, 6, 220],
-    [3, "keyword", e[9], 221,
-     0, 223],
-    [1, 6, 222],
-    [3, "def", e[10], 223],
-    [1, 6, 224],
-    [",", 225,
-     0, -1],
-    [1, 6, 226],
-    [e[10], 227,
-     0, 228],
-    [1, 6, 229],
-    [1, 6, 224],
-    [3, "keyword", e[9], 230,
-     0, 228],
-    [1, 6, 231],
-    [3, "def", e[10], 228],
-    [3, "variable", e[10], 233],
-    [1, 6, 234],
-    [",", 235,
-     0, -1],
-    [1, 6, 236],
-    [3, "variable", e[10], 237,
-     0, 237],
-    [1, 6, 234],
-    [1, 308, -1],
-    [2, 316, -1, {"name":"ParenExpr"},
-     2, 321, -1, {"name":"ArrayLiteral"},
-     2, 326, -1, {"name":"ObjectLiteral"},
-     3, "number", e[25], -1,
-     0, 240,
-     3, "operator", "...", -1,
-     3, "atom", e[26], -1,
-     3, "atom", e[27], -1,
-     3, "keyword", e[28], 243,
-     3, "keyword", e[29], 247,
-     3, "builtin", e[30], -1,
-     3, "variable callee", e[33], -1,
-     3, "variable", e[10], -1],
-    [2, 53, 241, {"name":"string","token":"string"},
-     1, 55, 241],
-    [1, 6, 242],
-    [0, 240,
-     0, -1],
-    [1, 6, 244],
-    [3, "keyword", e[21], 245,
-     1, 120, -1,
-     0, -1],
-    [1, 6, 246],
-    [1, 120, -1],
-    [1, 6, 248],
-    [2, 333, -1, {"name":"LambdaDef"}],
-    [3, "operator", e[31], 250,
-     3, "keyword", e[32], 250,
-     2, 141, -1, {"name":"ArgList"},
-     2, 338, -1, {"name":"Subscript"},
-     ".", 252,
-     3, "keyword", e[0], 254],
-    [1, 6, 251],
-    [1, 120, -1],
-    [1, 6, 253],
-    [3, "property callee", e[33], -1,
-     3, "property", e[10], -1],
-    [1, 6, 255],
-    [1, 120, 256],
-    [1, 6, 257],
-    [3, "keyword", e[2], 258,
-     0, -1],
-    [1, 6, 259],
-    [1, 120, -1],
-    [3, "operator", e[23], 261,
-     3, "keyword", e[24], 261,
-     1, 239, 262],
-    [1, 6, 260],
-    [1, 6, 263],
-    [1, 343, 264,
-     3, "keyword", e[8], 265,
-     0, -1],
-    [1, 6, 263],
-    [1, 6, 266],
-    [1, 120, 264],
-    ["\n", 268],
-    [/^[ \t]/, 268,
-     3, "comment", /^\#.*/, 268,
-     "\n", 268,
-     0, 269],
-    [[0, [7, "stillIndented"], [6, 354]], 270,
-     [0, [7, "stillIndented"], /^(?=return|pass)/], 272,
-     0, -1],
-    [2, 9, 271, {"name":"Statement"}],
-    [/^[ \t]/, 271,
-     3, "comment", /^\#.*/, 271,
-     "\n", 271,
-     0, 269],
-    [2, 9, -1, {"name":"Statement"}],
-    [1, 238, 274],
-    [1, 6, 275],
-    [3, "keyword", e[8], -1],
-    [3, "operator", e[23], 277,
-     3, "keyword", e[24], 277,
-     1, 239, 278],
-    [1, 6, 276],
-    [1, 6, 279],
-    [1, 355, 280,
-     0, -1],
-    [1, 6, 279],
-    [3, "variable-2", e[35], 282,
-     3, "operator", "**", 283,
-     3, "meta", e[34], 284,
-     0, 283],
-    [1, 6, 285],
-    [1, 6, 286],
-    [1, 6, 287],
-    [1, 343, 288,
-     0, 289],
-    [1, 260, 289],
-    ["=", 283],
-    [1, 6, 285],
-    [1, 6, 290],
-    [",", 291,
-     1, 366, -1,
-     0, -1],
-    [1, 6, 292],
-    [1, 378, -1,
-     0, -1],
-    ["(", 294],
-    [1, 6, 295],
-    [1, 238, 296],
-    [1, 6, 297],
-    [")", -1],
-    ["[", 299],
-    [1, 6, 300],
-    [1, 238, 301],
-    [1, 6, 302],
-    ["]", -1],
-    ["(", 304],
-    [1, 6, 305],
-    [1, 392, 306,
-     0, 306],
-    [1, 6, 307],
-    [")", -1],
-    [[6, 418], 309,
-     2, 293, 310, {"name":"ParenPattern"},
-     2, 298, 310, {"name":"BracketPattern"}],
-    [3, "def", e[10], 310],
-    [1, 6, 311],
-    [",", 312,
-     0, -1],
-    [1, 6, 313],
-    [[6, 418], 314,
-     2, 293, 315, {"name":"ParenPattern"},
-     2, 298, 315, {"name":"BracketPattern"},
-     0, 315],
-    [3, "def", e[10], 315],
-    [1, 6, 311],
-    ["(", 317],
-    [1, 6, 318],
-    [1, 419, 319,
-     0, 319],
-    [1, 6, 320],
-    [")", -1],
-    ["[", 322],
-    [1, 6, 323],
-    [1, 419, 324,
-     0, 324],
-    [1, 6, 325],
-    ["]", -1],
-    ["{", 327],
-    [1, 6, 328],
-    [1, 427, 329,
-     0, 331],
-    [1, 6, 330],
-    [1, 366, 331,
-     0, 331],
-    [1, 6, 332],
-    ["}", -1],
-    [1, 433, 334,
-     0, 334],
-    [1, 6, 335],
-    [":", 336],
-    [1, 6, 337],
-    [1, 260, -1],
-    ["[", 339],
-    [1, 6, 340],
-    [1, 451, 341],
-    [1, 6, 342],
-    ["]", -1],
-    [3, "operator", e[31], 344,
-     3, "keyword", e[32], 344,
-     2, 141, -1, {"name":"ArgList"},
-     2, 338, -1, {"name":"Subscript"},
-     ".", 346,
-     3, "keyword", e[0], 348],
-    [1, 6, 345],
-    [1, 260, -1],
-    [1, 6, 347],
-    [3, "property callee", e[33], -1,
-     3, "property", e[10], -1],
-    [1, 6, 349],
-    [1, 260, 350],
-    [1, 6, 351],
-    [3, "keyword", e[2], 352,
-     0, -1],
-    [1, 6, 353],
-    [1, 260, -1],
-    [3, "keyword", /^(?:return|pass)(?![a-zA-Z¡-￿_0-9_])/, -1],
-    [3, "operator", e[31], 356,
-     3, "keyword", e[32], 356,
-     2, 141, -1, {"name":"ArgList"},
-     2, 338, -1, {"name":"Subscript"},
-     ".", 358,
-     3, "keyword", e[0], 360],
-    [1, 6, 357],
-    [1, 276, -1],
-    [1, 6, 359],
-    [3, "property callee", e[33], -1,
-     3, "property", e[10], -1],
-    [1, 6, 361],
-    [1, 276, 362],
-    [1, 6, 363],
-    [3, "keyword", e[2], 364,
-     0, -1],
-    [1, 6, 365],
-    [1, 276, -1],
-    [3, "keyword", e[6], 367,
-     0, 367],
-    [1, 6, 368],
-    [3, "keyword", e[4], 369],
-    [1, 6, 370],
-    [[5, 273], 371,
-     1, 276, 372],
-    [1, 238, 372],
-    [1, 6, 373],
-    [3, "keyword", e[8], 374],
-    [1, 6, 375],
-    [1, 120, 376],
-    [1, 6, 377],
-    [1, 366, -1,
-     1, 485, -1,
-     0, -1],
-    [3, "operator", "**", 379,
-     3, "meta", e[34], 380,
-     0, 379],
-    [1, 6, 381],
-    [1, 6, 382],
-    [1, 260, 383],
-    ["=", 379],
-    [1, 6, 384],
-    [",", 385,
-     0, -1],
-    [1, 6, 386],
-    [3, "operator", "**", 387,
-     3, "meta", e[34], 388,
-     0, 387,
-     0, 389],
-    [1, 6, 390],
-    [1, 6, 391],
-    [1, 6, 384],
-    [1, 260, 389],
-    ["=", 387],
-    [2, 490, 393, {"name":"op","token":"operator"},
-     0, 393],
-    [1, 6, 394],
-    [3, "atom", e[27], 395,
-     3, "def", e[10], 395],
-    [1, 6, 396],
-    [":", 397,
-     0, 398],
-    [1, 6, 399],
-    [1, 6, 400],
-    [1, 260, 398],
-    [3, "operator", "=", 401,
-     0, 403],
-    [1, 6, 402],
-    [1, 260, 403],
-    [1, 6, 404],
-    [",", 405,
-     0, -1],
-    [1, 6, 406],
-    [2, 490, 407, {"name":"op","token":"operator"},
-     0, 407,
-     0, 408],
-    [1, 6, 409],
-    [1, 6, 404],
-    [3, "atom", e[27], 410,
-     3, "def", e[10], 410],
-    [1, 6, 411],
-    [":", 412,
-     0, 413],
-    [1, 6, 414],
-    [1, 6, 415],
-    [1, 260, 413],
-    [3, "operator", "=", 416,
-     0, 408],
-    [1, 6, 417],
-    [1, 260, 408],
-    [3, "keyword", e[8], -1],
-    [3, "variable-2", e[35], 420,
-     1, 260, 423],
-    [1, 6, 421],
-    [1, 343, 422,
-     0, 423],
-    [1, 6, 421],
-    [1, 6, 424],
-    [",", 425,
-     1, 366, -1,
-     0, -1],
-    [1, 6, 426],
-    [1, 493, -1,
-     0, -1],
-    [2, 499, 428, {"name":"DictProp"}],
-    [1, 6, 429],
-    [",", 430,
-     0, -1],
-    [1, 6, 431],
-    [2, 499, 432, {"name":"DictProp"},
-     0, 432],
-    [1, 6, 429],
-    [3, "operator", e[36], 434,
-     0, 434],
-    [1, 6, 435],
-    [3, "def", e[10], 436],
-    [1, 6, 437],
-    [3, "operator", "=", 438,
-     0, 440],
-    [1, 6, 439],
-    [1, 260, 440],
-    [1, 6, 441],
-    [",", 442,
-     0, -1],
-    [1, 6, 443],
-    [3, "operator", e[36], 444,
-     0, 444,
-     0, 445],
-    [1, 6, 446],
-    [1, 6, 441],
-    [3, "def", e[10], 447],
-    [1, 6, 448],
-    [3, "operator", "=", 449,
-     0, 445],
-    [1, 6, 450],
-    [1, 260, 445],
-    [1, 260, 452,
-     ":", 453],
-    [1, 6, 454],
-    [1, 6, 455],
-    [":", 456,
-     0, 466],
-    [1, 260, 457,
-     0, 457],
-    [1, 6, 458],
-    [1, 6, 459],
-    [1, 260, 460,
-     0, 460],
-    [":", 461,
-     0, 466],
-    [1, 6, 462],
-    [1, 6, 463],
-    [":", 464,
-     0, 466],
-    [1, 260, 466,
-     0, 466],
-    [1, 6, 465],
-    [1, 260, 466,
-     0, 466],
-    [1, 6, 467],
-    [",", 468,
-     0, -1],
-    [1, 6, 469],
-    [1, 260, 470,
-     ":", 471,
-     0, 472],
-    [1, 6, 473],
-    [1, 6, 474],
-    [1, 6, 467],
-    [":", 475,
-     0, 472],
-    [1, 260, 476,
-     0, 476],
-    [1, 6, 477],
-    [1, 6, 478],
-    [1, 260, 479,
-     0, 479],
-    [":", 480,
-     0, 472],
-    [1, 6, 481],
-    [1, 6, 482],
-    [":", 483,
-     0, 472],
-    [1, 260, 472,
-     0, 472],
-    [1, 6, 484],
-    [1, 260, 472,
-     0, 472],
-    [3, "keyword", e[0], 486],
-    [1, 6, 487],
-    [1, 120, 488],
-    [1, 6, 489],
-    [1, 366, -1,
-     1, 485, -1,
-     0, -1],
-    ["*", 491],
-    [1, 6, 492],
-    [/^\*?/, -1],
-    [1, 260, 494],
-    [1, 6, 495],
-    [",", 496,
-     0, -1],
-    [1, 6, 497],
-    [1, 260, 498,
-     0, 498],
-    [1, 6, 495],
-    [3, "operator", "**", 500,
-     1, 260, 502],
-    [1, 6, 501],
-    [1, 260, -1],
-    [1, 6, 503],
-    [":", 504,
-     0, -1],
-    [1, 6, 505],
-    [1, 260, -1]
-  ];
-  var start = 0;
-  var token = 5;
+  var nodes = {
+    "_start": [
+      1, "whitespace", "_start$2"
+    ],
+    "_start$1": [
+      /^[^]/, "_start"
+    ],
+    "_start$2": [
+      1, "whitespace", "_start$3"
+    ],
+    "_start$3": [
+      "\n", "_start$4",
+      2, "Statement", "_start$4", {"name":"Statement"},
+      0, "_start$1"
+    ],
+    "_start$4": [
+      1, "whitespace", "_start$3"
+    ],
+    "_token": [
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:while|elif)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^else(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:try|finally)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^for(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^async(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^def(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^except(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^class(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^with(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^lambda(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^del(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^yield(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^raise(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^from(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^import(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:pass|break|continue)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:global|nonlocal)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:return|assert)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:not|await)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "atom", /^(?:None|True|False)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "atom", /^self(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^(?:or|and|in|is(?: +not)?|not(?: +in)?)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "builtin", /^(?:abs|all|any|bin|bool|bytearray|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__|NotImplemented|Ellipsis|__debug__|ascii|bytes|exec|print)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "builtin", /^print(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "operator", /^(?:(?:\^|\&|\||\<\<|\>\>|\+|\-|\*\*?|\@|\/|\%|\/)\=?|\=|\<|\>|\=\=|\>\=|\<\=|\<\>|\!\=|\:\=)/, -1,
+      3, "operator", /^[\*\+\-\~]/, -1,
+      3, "number", /^(?:(?:0b|OB)[01_]+|(?:0o|0O)[0-7_]+|(?:0x|OX)[0-9a-fA-F_]+|(?:[0-9][0-9_]*(?:l|L|\.[0-9_]+)?|\.[0-9_]+)(?:[eE][\+\-]?[0-9_]+)?[jJ]?)/, -1,
+      2, "string", -1, {"name":"string","token":"string"},
+      1, "fstring", -1,
+      3, "variable", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, -1,
+      3, "comment", /^\#.*/, -1,
+      /^[^]/, -1
+    ],
+    "whitespace": [
+      /^[ \t]/, "whitespace",
+      3, "comment", /^\#.*/, "whitespace",
+      "\\", "whitespace$1",
+      [0, /^(?=\n)/, [7, "maySkipNewline"]], "whitespace$2",
+      0, -1
+    ],
+    "whitespace$1": [
+      "\n", "whitespace"
+    ],
+    "whitespace$2": [
+      "\n", "whitespace"
+    ],
+    "Statement": [
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, "Statement$1",
+      3, "keyword", /^(?:while|elif)(?![a-zA-Z¡-￿_0-9_])/, "Statement$1",
+      3, "keyword", /^else(?![a-zA-Z¡-￿_0-9_])/, "Statement$7",
+      3, "keyword", /^(?:try|finally)(?![a-zA-Z¡-￿_0-9_])/, "Statement$7",
+      3, "keyword", /^for(?![a-zA-Z¡-￿_0-9_])/, "Statement$11",
+      3, "keyword", /^except(?![a-zA-Z¡-￿_0-9_])/, "Statement$21",
+      3, "keyword", /^async(?![a-zA-Z¡-￿_0-9_])/, "Statement$31",
+      1, "AsyncStatement", -1,
+      2, "Annotation", "Statement$33", {"name":"Annotation","token":"meta"},
+      3, "builtin", /^print(?![a-zA-Z¡-￿_0-9_])/, "Statement$37",
+      1, "SmallStatement", "Statement$39"
+    ],
+    "Statement$1": [
+      1, "whitespace", "Statement$2"
+    ],
+    "Statement$2": [
+      1, "Expr", "Statement$3"
+    ],
+    "Statement$3": [
+      1, "whitespace", "Statement$4"
+    ],
+    "Statement$4": [
+      ":", "Statement$5"
+    ],
+    "Statement$5": [
+      1, "whitespace", "Statement$6"
+    ],
+    "Statement$6": [
+      1, "Body", -1
+    ],
+    "Statement$7": [
+      1, "whitespace", "Statement$8"
+    ],
+    "Statement$8": [
+      ":", "Statement$9"
+    ],
+    "Statement$9": [
+      1, "whitespace", "Statement$10"
+    ],
+    "Statement$10": [
+      1, "Body", -1
+    ],
+    "Statement$11": [
+      1, "whitespace", "Statement$12"
+    ],
+    "Statement$12": [
+      1, "CommaSep_9", "Statement$13"
+    ],
+    "Statement$13": [
+      1, "whitespace", "Statement$14"
+    ],
+    "Statement$14": [
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, "Statement$15"
+    ],
+    "Statement$15": [
+      1, "whitespace", "Statement$16"
+    ],
+    "Statement$16": [
+      1, "Expr", "Statement$17"
+    ],
+    "Statement$17": [
+      1, "whitespace", "Statement$18"
+    ],
+    "Statement$18": [
+      ":", "Statement$19"
+    ],
+    "Statement$19": [
+      1, "whitespace", "Statement$20"
+    ],
+    "Statement$20": [
+      1, "Body", -1
+    ],
+    "Statement$21": [
+      1, "whitespace", "Statement$22"
+    ],
+    "Statement$22": [
+      1, "Expr", "Statement$23",
+      0, "Statement$24"
+    ],
+    "Statement$23": [
+      1, "whitespace", "Statement$25"
+    ],
+    "Statement$24": [
+      1, "whitespace", "Statement$26"
+    ],
+    "Statement$25": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "Statement$27",
+      0, "Statement$24"
+    ],
+    "Statement$26": [
+      ":", "Statement$28"
+    ],
+    "Statement$27": [
+      1, "whitespace", "Statement$29"
+    ],
+    "Statement$28": [
+      1, "whitespace", "Statement$30"
+    ],
+    "Statement$29": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "Statement$24"
+    ],
+    "Statement$30": [
+      1, "Body", -1
+    ],
+    "Statement$31": [
+      1, "whitespace", "Statement$32"
+    ],
+    "Statement$32": [
+      1, "AsyncStatement", -1
+    ],
+    "Statement$33": [
+      1, "whitespace", "Statement$34"
+    ],
+    "Statement$34": [
+      2, "ArgList", "Statement$35", {"name":"ArgList"},
+      0, "Statement$35"
+    ],
+    "Statement$35": [
+      1, "whitespace", "Statement$36"
+    ],
+    "Statement$36": [
+      "\n", -1
+    ],
+    "Statement$37": [
+      1, "whitespace", "Statement$38"
+    ],
+    "Statement$38": [
+      2, "ArgList", -1, {"name":"ArgList"},
+      1, "Expr", -1
+    ],
+    "Statement$39": [
+      1, "whitespace", "Statement$40"
+    ],
+    "Statement$40": [
+      ";", "Statement$41",
+      "\n", -1
+    ],
+    "Statement$41": [
+      1, "whitespace", "Statement$42"
+    ],
+    "Statement$42": [
+      1, "SmallStatement", "Statement$43",
+      0, "Statement$43"
+    ],
+    "Statement$43": [
+      1, "whitespace", "Statement$40"
+    ],
+    "string": [
+      /^[uUrRbB]+(?=[\'\"])/, "string$1",
+      1, "stringQuoted", -1
+    ],
+    "string$1": [
+      1, "stringQuoted", -1
+    ],
+    "fstring": [
+      3, "string", /^[uUrR]*[fF][uUrR]*(?=[\'\"])/, "fstring$1"
+    ],
+    "fstring$1": [
+      3, "string", "'''", "fstring$2",
+      3, "string", "\"\"\"", "fstring$3",
+      3, "string", "'", "fstring$4",
+      3, "string", "\"", "fstring$5"
+    ],
+    "fstring$2": [
+      /^(?!\'\'\')/, "fstring$6",
+      3, "string", "{{", "fstring$2",
+      3, "string", "}}", "fstring$2",
+      1, "replacementField", "fstring$2",
+      3, "string", "'''", -1
+    ],
+    "fstring$3": [
+      /^(?!\"\"\")/, "fstring$7",
+      3, "string", "{{", "fstring$3",
+      3, "string", "}}", "fstring$3",
+      1, "replacementField", "fstring$3",
+      3, "string", "\"\"\"", -1
+    ],
+    "fstring$4": [
+      3, "string", "\\", "fstring$8",
+      /^(?!\')/, "fstring$9",
+      3, "string", "{{", "fstring$4",
+      3, "string", "}}", "fstring$4",
+      1, "replacementField", "fstring$4",
+      3, "string", "'", -1
+    ],
+    "fstring$5": [
+      3, "string", "\\", "fstring$10",
+      /^(?!\")/, "fstring$11",
+      3, "string", "{{", "fstring$5",
+      3, "string", "}}", "fstring$5",
+      1, "replacementField", "fstring$5",
+      3, "string", "\"", -1
+    ],
+    "fstring$6": [
+      3, "string", [0, /^(?![\{\}])/, /^[^]/], "fstring$2"
+    ],
+    "fstring$7": [
+      3, "string", [0, /^(?![\{\}])/, /^[^]/], "fstring$3"
+    ],
+    "fstring$8": [
+      3, "string", [0, /^(?![\{\}])/, /^[^]/], "fstring$4"
+    ],
+    "fstring$9": [
+      3, "string", /^(?![\{\}])./, "fstring$4"
+    ],
+    "fstring$10": [
+      3, "string", [0, /^(?![\{\}])/, /^[^]/], "fstring$5"
+    ],
+    "fstring$11": [
+      3, "string", /^(?![\{\}])./, "fstring$5"
+    ],
+    "AsyncStatement": [
+      3, "keyword", /^with(?![a-zA-Z¡-￿_0-9_])/, "AsyncStatement$1",
+      3, "keyword", /^def(?![a-zA-Z¡-￿_0-9_])/, "AsyncStatement$7",
+      3, "keyword", /^class(?![a-zA-Z¡-￿_0-9_])/, "AsyncStatement$11"
+    ],
+    "AsyncStatement$1": [
+      1, "whitespace", "AsyncStatement$2"
+    ],
+    "AsyncStatement$2": [
+      1, "CommaSep_10", "AsyncStatement$3"
+    ],
+    "AsyncStatement$3": [
+      1, "whitespace", "AsyncStatement$4"
+    ],
+    "AsyncStatement$4": [
+      ":", "AsyncStatement$5"
+    ],
+    "AsyncStatement$5": [
+      1, "whitespace", "AsyncStatement$6"
+    ],
+    "AsyncStatement$6": [
+      1, "Body", -1
+    ],
+    "AsyncStatement$7": [
+      1, "whitespace", "AsyncStatement$8"
+    ],
+    "AsyncStatement$8": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "AsyncStatement$9"
+    ],
+    "AsyncStatement$9": [
+      1, "whitespace", "AsyncStatement$10"
+    ],
+    "AsyncStatement$10": [
+      2, "FuncDef", -1, {"name":"FuncDef"}
+    ],
+    "AsyncStatement$11": [
+      1, "whitespace", "AsyncStatement$12"
+    ],
+    "AsyncStatement$12": [
+      2, "ClassDef", -1, {"name":"ClassDef"}
+    ],
+    "Annotation": [
+      "@", "Annotation$1"
+    ],
+    "Annotation$1": [
+      1, "whitespace", "Annotation$2"
+    ],
+    "Annotation$2": [
+      /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "Annotation$3"
+    ],
+    "Annotation$3": [
+      1, "whitespace", "Annotation$4"
+    ],
+    "Annotation$4": [
+      ".", "Annotation$5",
+      0, -1
+    ],
+    "Annotation$5": [
+      1, "whitespace", "Annotation$6"
+    ],
+    "Annotation$6": [
+      /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "Annotation$7"
+    ],
+    "Annotation$7": [
+      1, "whitespace", "Annotation$4"
+    ],
+    "SmallStatement": [
+      3, "keyword", /^(?:pass|break|continue)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^del(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$1",
+      3, "keyword", /^(?:return|assert)(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$3",
+      3, "keyword", /^raise(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$5",
+      3, "keyword", /^import(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$11",
+      3, "keyword", /^from(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$13",
+      3, "keyword", /^(?:global|nonlocal)(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$21",
+      [5, "_lookahead_4"], "SmallStatement$23",
+      1, "Expr", -1
+    ],
+    "SmallStatement$1": [
+      1, "whitespace", "SmallStatement$2"
+    ],
+    "SmallStatement$2": [
+      1, "Expr", -1
+    ],
+    "SmallStatement$3": [
+      1, "whitespace", "SmallStatement$4"
+    ],
+    "SmallStatement$4": [
+      1, "Expr", -1,
+      0, -1
+    ],
+    "SmallStatement$5": [
+      1, "whitespace", "SmallStatement$6"
+    ],
+    "SmallStatement$6": [
+      1, "Expr", "SmallStatement$7",
+      0, "SmallStatement$7"
+    ],
+    "SmallStatement$7": [
+      1, "whitespace", "SmallStatement$8"
+    ],
+    "SmallStatement$8": [
+      3, "keyword", /^from(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$9",
+      0, -1
+    ],
+    "SmallStatement$9": [
+      1, "whitespace", "SmallStatement$10"
+    ],
+    "SmallStatement$10": [
+      1, "Expr", -1
+    ],
+    "SmallStatement$11": [
+      1, "whitespace", "SmallStatement$12"
+    ],
+    "SmallStatement$12": [
+      1, "CommaSep_6", -1
+    ],
+    "SmallStatement$13": [
+      1, "whitespace", "SmallStatement$14"
+    ],
+    "SmallStatement$14": [
+      ".", "SmallStatement$15",
+      [6, "_lookahead_3"], "SmallStatement$16",
+      3, "keyword", /^import(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$17"
+    ],
+    "SmallStatement$15": [
+      1, "whitespace", "SmallStatement$14"
+    ],
+    "SmallStatement$16": [
+      1, "Expr", "SmallStatement$18"
+    ],
+    "SmallStatement$17": [
+      1, "whitespace", "SmallStatement$19"
+    ],
+    "SmallStatement$18": [
+      1, "whitespace", "SmallStatement$20"
+    ],
+    "SmallStatement$19": [
+      "*", -1,
+      2, "FromImportList", -1, {"name":"FromImportList"},
+      1, "CommaSep_7", -1
+    ],
+    "SmallStatement$20": [
+      3, "keyword", /^import(?![a-zA-Z¡-￿_0-9_])/, "SmallStatement$17"
+    ],
+    "SmallStatement$21": [
+      1, "whitespace", "SmallStatement$22"
+    ],
+    "SmallStatement$22": [
+      1, "CommaSep_8", -1
+    ],
+    "SmallStatement$23": [
+      1, "Pattern", "SmallStatement$24"
+    ],
+    "SmallStatement$24": [
+      1, "whitespace", "SmallStatement$25"
+    ],
+    "SmallStatement$25": [
+      ":", "SmallStatement$26",
+      0, "SmallStatement$27"
+    ],
+    "SmallStatement$26": [
+      1, "whitespace", "SmallStatement$28"
+    ],
+    "SmallStatement$27": [
+      1, "whitespace", "SmallStatement$29"
+    ],
+    "SmallStatement$28": [
+      1, "Expr", "SmallStatement$27"
+    ],
+    "SmallStatement$29": [
+      3, "operator", "=", "SmallStatement$30",
+      0, -1
+    ],
+    "SmallStatement$30": [
+      1, "whitespace", "SmallStatement$31"
+    ],
+    "SmallStatement$31": [
+      1, "Expr", -1
+    ],
+    "Expr": [
+      3, "operator", /^[\*\+\-\~]/, "Expr$1",
+      3, "keyword", /^(?:not|await)(?![a-zA-Z¡-￿_0-9_])/, "Expr$1",
+      1, "BaseExpr", "Expr$2"
+    ],
+    "Expr$1": [
+      1, "whitespace", "Expr"
+    ],
+    "Expr$2": [
+      1, "whitespace", "Expr$3"
+    ],
+    "Expr$3": [
+      1, "ExprSuffix_2", "Expr$4",
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, "Expr$5",
+      ",", "Expr$5",
+      0, -1
+    ],
+    "Expr$4": [
+      1, "whitespace", "Expr$3"
+    ],
+    "Expr$5": [
+      1, "whitespace", "Expr$6"
+    ],
+    "Expr$6": [
+      1, "ExprNoComma", "Expr$4"
+    ],
+    "Body": [
+      1, "SmallStatement", "Body$1",
+      2, "indentedBody", -1, {"name":"indentedBody"}
+    ],
+    "Body$1": [
+      1, "whitespace", "Body$2"
+    ],
+    "Body$2": [
+      ";", "Body$3",
+      "\n", -1
+    ],
+    "Body$3": [
+      1, "whitespace", "Body$4"
+    ],
+    "Body$4": [
+      1, "SmallStatement", "Body$5",
+      0, "Body$5"
+    ],
+    "Body$5": [
+      1, "whitespace", "Body$2"
+    ],
+    "CommaSep_9": [
+      [5, "_lookahead_6"], "CommaSep_9$1",
+      1, "ExprNoIn", "CommaSep_9$2"
+    ],
+    "CommaSep_9$1": [
+      1, "Pattern", "CommaSep_9$2"
+    ],
+    "CommaSep_9$2": [
+      1, "whitespace", "CommaSep_9$3"
+    ],
+    "CommaSep_9$3": [
+      ",", "CommaSep_9$4",
+      0, -1
+    ],
+    "CommaSep_9$4": [
+      1, "whitespace", "CommaSep_9$5"
+    ],
+    "CommaSep_9$5": [
+      [5, "_lookahead_6"], "CommaSep_9$6",
+      1, "ExprNoIn", "CommaSep_9$7",
+      0, "CommaSep_9$7"
+    ],
+    "CommaSep_9$6": [
+      1, "Pattern", "CommaSep_9$7"
+    ],
+    "CommaSep_9$7": [
+      1, "whitespace", "CommaSep_9$3"
+    ],
+    "ArgList": [
+      "(", "ArgList$1"
+    ],
+    "ArgList$1": [
+      1, "whitespace", "ArgList$2"
+    ],
+    "ArgList$2": [
+      1, "MaybeComp_1", "ArgList$3",
+      0, "ArgList$3"
+    ],
+    "ArgList$3": [
+      1, "whitespace", "ArgList$4"
+    ],
+    "ArgList$4": [
+      ")", -1
+    ],
+    "stringQuoted": [
+      "'''", "stringQuoted$1",
+      "\"\"\"", "stringQuoted$3",
+      "'", "stringQuoted$5",
+      "\"", "stringQuoted$7"
+    ],
+    "stringQuoted$1": [
+      "\\", "stringQuoted$2",
+      [0, /^(?!\'\'\')/, /^[^]/], "stringQuoted$1",
+      "'''", -1
+    ],
+    "stringQuoted$2": [
+      /^[^]/, "stringQuoted$1"
+    ],
+    "stringQuoted$3": [
+      "\\", "stringQuoted$4",
+      [0, /^(?!\"\"\")/, /^[^]/], "stringQuoted$3",
+      "\"\"\"", -1
+    ],
+    "stringQuoted$4": [
+      /^[^]/, "stringQuoted$3"
+    ],
+    "stringQuoted$5": [
+      "\\", "stringQuoted$6",
+      /^(?!\')./, "stringQuoted$5",
+      "'", -1
+    ],
+    "stringQuoted$6": [
+      /^[^]/, "stringQuoted$5"
+    ],
+    "stringQuoted$7": [
+      "\\", "stringQuoted$8",
+      /^(?!\")./, "stringQuoted$7",
+      "\"", -1
+    ],
+    "stringQuoted$8": [
+      /^[^]/, "stringQuoted$7"
+    ],
+    "replacementField": [
+      3, "operator", "{", "replacementField$1"
+    ],
+    "replacementField$1": [
+      1, "Expr", "replacementField$2",
+      0, "replacementField$2"
+    ],
+    "replacementField$2": [
+      3, "operator", "=", "replacementField$3",
+      0, "replacementField$3"
+    ],
+    "replacementField$3": [
+      3, "operator", "!", "replacementField$4",
+      0, "replacementField$5"
+    ],
+    "replacementField$4": [
+      3, "keyword", /^(?:(?![\:\} \t]).)*/, "replacementField$5"
+    ],
+    "replacementField$5": [
+      3, "operator", ":", "replacementField$6",
+      0, "replacementField$7"
+    ],
+    "replacementField$6": [
+      3, "string", /^(?![\{\}])./, "replacementField$6",
+      1, "replacementField", "replacementField$6",
+      0, "replacementField$7"
+    ],
+    "replacementField$7": [
+      3, "operator", "}", -1
+    ],
+    "CommaSep_10": [
+      1, "ExprNoComma", "CommaSep_10$1"
+    ],
+    "CommaSep_10$1": [
+      1, "whitespace", "CommaSep_10$2"
+    ],
+    "CommaSep_10$2": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_10$3",
+      0, "CommaSep_10$5"
+    ],
+    "CommaSep_10$3": [
+      1, "whitespace", "CommaSep_10$4"
+    ],
+    "CommaSep_10$4": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_10$5",
+      2, "ParenPattern", "CommaSep_10$5", {"name":"ParenPattern"},
+      2, "BracketPattern", "CommaSep_10$5", {"name":"BracketPattern"}
+    ],
+    "CommaSep_10$5": [
+      1, "whitespace", "CommaSep_10$6"
+    ],
+    "CommaSep_10$6": [
+      ",", "CommaSep_10$7",
+      0, -1
+    ],
+    "CommaSep_10$7": [
+      1, "whitespace", "CommaSep_10$8"
+    ],
+    "CommaSep_10$8": [
+      1, "ExprNoComma", "CommaSep_10$9",
+      0, "CommaSep_10$10"
+    ],
+    "CommaSep_10$9": [
+      1, "whitespace", "CommaSep_10$11"
+    ],
+    "CommaSep_10$10": [
+      1, "whitespace", "CommaSep_10$6"
+    ],
+    "CommaSep_10$11": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_10$12",
+      0, "CommaSep_10$10"
+    ],
+    "CommaSep_10$12": [
+      1, "whitespace", "CommaSep_10$13"
+    ],
+    "CommaSep_10$13": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_10$10",
+      2, "ParenPattern", "CommaSep_10$10", {"name":"ParenPattern"},
+      2, "BracketPattern", "CommaSep_10$10", {"name":"BracketPattern"}
+    ],
+    "FuncDef": [
+      2, "ParamList", "FuncDef$1", {"name":"ParamList"}
+    ],
+    "FuncDef$1": [
+      1, "whitespace", "FuncDef$2"
+    ],
+    "FuncDef$2": [
+      "->", "FuncDef$3",
+      0, "FuncDef$5"
+    ],
+    "FuncDef$3": [
+      1, "whitespace", "FuncDef$4"
+    ],
+    "FuncDef$4": [
+      1, "Expr", "FuncDef$5"
+    ],
+    "FuncDef$5": [
+      1, "whitespace", "FuncDef$6"
+    ],
+    "FuncDef$6": [
+      ":", "FuncDef$7"
+    ],
+    "FuncDef$7": [
+      1, "whitespace", "FuncDef$8"
+    ],
+    "FuncDef$8": [
+      1, "Body", -1
+    ],
+    "ClassDef": [
+      3, "type def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "ClassDef$1"
+    ],
+    "ClassDef$1": [
+      1, "whitespace", "ClassDef$2"
+    ],
+    "ClassDef$2": [
+      2, "ArgList", "ClassDef$3", {"name":"ArgList"},
+      0, "ClassDef$3"
+    ],
+    "ClassDef$3": [
+      1, "whitespace", "ClassDef$4"
+    ],
+    "ClassDef$4": [
+      ":", "ClassDef$5"
+    ],
+    "ClassDef$5": [
+      1, "whitespace", "ClassDef$6"
+    ],
+    "ClassDef$6": [
+      1, "Body", -1
+    ],
+    "_lookahead_4": [
+      1, "Pattern", "_lookahead_4$1"
+    ],
+    "_lookahead_4$1": [
+      1, "whitespace", "_lookahead_4$2"
+    ],
+    "_lookahead_4$2": [
+      /^[\=\:]/, -1
+    ],
+    "CommaSep_6": [
+      1, "ExprNoComma", "CommaSep_6$1"
+    ],
+    "CommaSep_6$1": [
+      1, "whitespace", "CommaSep_6$2"
+    ],
+    "CommaSep_6$2": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_6$3",
+      0, "CommaSep_6$5"
+    ],
+    "CommaSep_6$3": [
+      1, "whitespace", "CommaSep_6$4"
+    ],
+    "CommaSep_6$4": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_6$5"
+    ],
+    "CommaSep_6$5": [
+      1, "whitespace", "CommaSep_6$6"
+    ],
+    "CommaSep_6$6": [
+      ",", "CommaSep_6$7",
+      0, -1
+    ],
+    "CommaSep_6$7": [
+      1, "whitespace", "CommaSep_6$8"
+    ],
+    "CommaSep_6$8": [
+      1, "ExprNoComma", "CommaSep_6$9",
+      0, "CommaSep_6$10"
+    ],
+    "CommaSep_6$9": [
+      1, "whitespace", "CommaSep_6$11"
+    ],
+    "CommaSep_6$10": [
+      1, "whitespace", "CommaSep_6$6"
+    ],
+    "CommaSep_6$11": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_6$12",
+      0, "CommaSep_6$10"
+    ],
+    "CommaSep_6$12": [
+      1, "whitespace", "CommaSep_6$13"
+    ],
+    "CommaSep_6$13": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_6$10"
+    ],
+    "_lookahead_3": [
+      3, "keyword", /^import(?![a-zA-Z¡-￿_0-9_])/, -1
+    ],
+    "FromImportList": [
+      "(", "FromImportList$1"
+    ],
+    "FromImportList$1": [
+      1, "whitespace", "FromImportList$2"
+    ],
+    "FromImportList$2": [
+      1, "CommaSep_7", "FromImportList$3",
+      0, "FromImportList$3"
+    ],
+    "FromImportList$3": [
+      1, "whitespace", "FromImportList$4"
+    ],
+    "FromImportList$4": [
+      /^\,?/, "FromImportList$5"
+    ],
+    "FromImportList$5": [
+      1, "whitespace", "FromImportList$6"
+    ],
+    "FromImportList$6": [
+      ")", -1
+    ],
+    "CommaSep_7": [
+      /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_7$1"
+    ],
+    "CommaSep_7$1": [
+      1, "whitespace", "CommaSep_7$2"
+    ],
+    "CommaSep_7$2": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_7$3",
+      0, "CommaSep_7$5"
+    ],
+    "CommaSep_7$3": [
+      1, "whitespace", "CommaSep_7$4"
+    ],
+    "CommaSep_7$4": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_7$5"
+    ],
+    "CommaSep_7$5": [
+      1, "whitespace", "CommaSep_7$6"
+    ],
+    "CommaSep_7$6": [
+      ",", "CommaSep_7$7",
+      0, -1
+    ],
+    "CommaSep_7$7": [
+      1, "whitespace", "CommaSep_7$8"
+    ],
+    "CommaSep_7$8": [
+      /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_7$9",
+      0, "CommaSep_7$10"
+    ],
+    "CommaSep_7$9": [
+      1, "whitespace", "CommaSep_7$11"
+    ],
+    "CommaSep_7$10": [
+      1, "whitespace", "CommaSep_7$6"
+    ],
+    "CommaSep_7$11": [
+      3, "keyword", /^as(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_7$12",
+      0, "CommaSep_7$10"
+    ],
+    "CommaSep_7$12": [
+      1, "whitespace", "CommaSep_7$13"
+    ],
+    "CommaSep_7$13": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_7$10"
+    ],
+    "CommaSep_8": [
+      3, "variable", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_8$1"
+    ],
+    "CommaSep_8$1": [
+      1, "whitespace", "CommaSep_8$2"
+    ],
+    "CommaSep_8$2": [
+      ",", "CommaSep_8$3",
+      0, -1
+    ],
+    "CommaSep_8$3": [
+      1, "whitespace", "CommaSep_8$4"
+    ],
+    "CommaSep_8$4": [
+      3, "variable", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_8$5",
+      0, "CommaSep_8$5"
+    ],
+    "CommaSep_8$5": [
+      1, "whitespace", "CommaSep_8$2"
+    ],
+    "Pattern": [
+      1, "CommaSep_1", -1
+    ],
+    "BaseExpr": [
+      2, "ParenExpr", -1, {"name":"ParenExpr"},
+      2, "ArrayLiteral", -1, {"name":"ArrayLiteral"},
+      2, "ObjectLiteral", -1, {"name":"ObjectLiteral"},
+      3, "number", /^(?:(?:0b|OB)[01_]+|(?:0o|0O)[0-7_]+|(?:0x|OX)[0-9a-fA-F_]+|(?:[0-9][0-9_]*(?:l|L|\.[0-9_]+)?|\.[0-9_]+)(?:[eE][\+\-]?[0-9_]+)?[jJ]?)/, -1,
+      0, "BaseExpr$1",
+      3, "operator", "...", -1,
+      3, "atom", /^(?:None|True|False)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "atom", /^self(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "keyword", /^yield(?![a-zA-Z¡-￿_0-9_])/, "BaseExpr$4",
+      3, "keyword", /^lambda(?![a-zA-Z¡-￿_0-9_])/, "BaseExpr$8",
+      3, "builtin", /^(?:abs|all|any|bin|bool|bytearray|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__|NotImplemented|Ellipsis|__debug__|ascii|bytes|exec|print)(?![a-zA-Z¡-￿_0-9_])/, -1,
+      3, "variable callee", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?=\()/, -1,
+      3, "variable", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, -1
+    ],
+    "BaseExpr$1": [
+      2, "string", "BaseExpr$2", {"name":"string","token":"string"},
+      1, "fstring", "BaseExpr$2"
+    ],
+    "BaseExpr$2": [
+      1, "whitespace", "BaseExpr$3"
+    ],
+    "BaseExpr$3": [
+      0, "BaseExpr$1",
+      0, -1
+    ],
+    "BaseExpr$4": [
+      1, "whitespace", "BaseExpr$5"
+    ],
+    "BaseExpr$5": [
+      3, "keyword", /^from(?![a-zA-Z¡-￿_0-9_])/, "BaseExpr$6",
+      1, "Expr", -1,
+      0, -1
+    ],
+    "BaseExpr$6": [
+      1, "whitespace", "BaseExpr$7"
+    ],
+    "BaseExpr$7": [
+      1, "Expr", -1
+    ],
+    "BaseExpr$8": [
+      1, "whitespace", "BaseExpr$9"
+    ],
+    "BaseExpr$9": [
+      2, "LambdaDef", -1, {"name":"LambdaDef"}
+    ],
+    "ExprSuffix_2": [
+      3, "operator", /^(?:(?:\^|\&|\||\<\<|\>\>|\+|\-|\*\*?|\@|\/|\%|\/)\=?|\=|\<|\>|\=\=|\>\=|\<\=|\<\>|\!\=|\:\=)/, "ExprSuffix_2$1",
+      3, "keyword", /^(?:or|and|in|is(?: +not)?|not(?: +in)?)(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_2$1",
+      2, "ArgList", -1, {"name":"ArgList"},
+      2, "Subscript", -1, {"name":"Subscript"},
+      ".", "ExprSuffix_2$3",
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_2$5"
+    ],
+    "ExprSuffix_2$1": [
+      1, "whitespace", "ExprSuffix_2$2"
+    ],
+    "ExprSuffix_2$2": [
+      1, "Expr", -1
+    ],
+    "ExprSuffix_2$3": [
+      1, "whitespace", "ExprSuffix_2$4"
+    ],
+    "ExprSuffix_2$4": [
+      3, "property callee", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?=\()/, -1,
+      3, "property", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, -1
+    ],
+    "ExprSuffix_2$5": [
+      1, "whitespace", "ExprSuffix_2$6"
+    ],
+    "ExprSuffix_2$6": [
+      1, "Expr", "ExprSuffix_2$7"
+    ],
+    "ExprSuffix_2$7": [
+      1, "whitespace", "ExprSuffix_2$8"
+    ],
+    "ExprSuffix_2$8": [
+      3, "keyword", /^else(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_2$9",
+      0, -1
+    ],
+    "ExprSuffix_2$9": [
+      1, "whitespace", "ExprSuffix_2$10"
+    ],
+    "ExprSuffix_2$10": [
+      1, "Expr", -1
+    ],
+    "ExprNoComma": [
+      3, "operator", /^[\*\+\-\~]/, "ExprNoComma$1",
+      3, "keyword", /^(?:not|await)(?![a-zA-Z¡-￿_0-9_])/, "ExprNoComma$1",
+      1, "BaseExpr", "ExprNoComma$2"
+    ],
+    "ExprNoComma$1": [
+      1, "whitespace", "ExprNoComma"
+    ],
+    "ExprNoComma$2": [
+      1, "whitespace", "ExprNoComma$3"
+    ],
+    "ExprNoComma$3": [
+      1, "ExprSuffix", "ExprNoComma$4",
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, "ExprNoComma$5",
+      0, -1
+    ],
+    "ExprNoComma$4": [
+      1, "whitespace", "ExprNoComma$3"
+    ],
+    "ExprNoComma$5": [
+      1, "whitespace", "ExprNoComma$6"
+    ],
+    "ExprNoComma$6": [
+      1, "Expr", "ExprNoComma$4"
+    ],
+    "indentedBody": [
+      "\n", "indentedBody$1"
+    ],
+    "indentedBody$1": [
+      /^[ \t]/, "indentedBody$1",
+      3, "comment", /^\#.*/, "indentedBody$1",
+      "\n", "indentedBody$1",
+      0, "indentedBody$2"
+    ],
+    "indentedBody$2": [
+      [0, [7, "stillIndented"], [6, "_lookahead_5"]], "indentedBody$3",
+      [0, [7, "stillIndented"], /^(?=return|pass)/], "indentedBody$5",
+      0, -1
+    ],
+    "indentedBody$3": [
+      2, "Statement", "indentedBody$4", {"name":"Statement"}
+    ],
+    "indentedBody$4": [
+      /^[ \t]/, "indentedBody$4",
+      3, "comment", /^\#.*/, "indentedBody$4",
+      "\n", "indentedBody$4",
+      0, "indentedBody$2"
+    ],
+    "indentedBody$5": [
+      2, "Statement", -1, {"name":"Statement"}
+    ],
+    "_lookahead_6": [
+      1, "Pattern", "_lookahead_6$1"
+    ],
+    "_lookahead_6$1": [
+      1, "whitespace", "_lookahead_6$2"
+    ],
+    "_lookahead_6$2": [
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, -1
+    ],
+    "ExprNoIn": [
+      3, "operator", /^[\*\+\-\~]/, "ExprNoIn$1",
+      3, "keyword", /^(?:not|await)(?![a-zA-Z¡-￿_0-9_])/, "ExprNoIn$1",
+      1, "BaseExpr", "ExprNoIn$2"
+    ],
+    "ExprNoIn$1": [
+      1, "whitespace", "ExprNoIn"
+    ],
+    "ExprNoIn$2": [
+      1, "whitespace", "ExprNoIn$3"
+    ],
+    "ExprNoIn$3": [
+      1, "ExprSuffix_1", "ExprNoIn$4",
+      0, -1
+    ],
+    "ExprNoIn$4": [
+      1, "whitespace", "ExprNoIn$3"
+    ],
+    "MaybeComp_1": [
+      3, "variable-2", [0, /^[a-zA-Z¡-￿__]/, /^[a-zA-Z¡-￿_0-9_]*/, [7, "isCompLocal"]], "MaybeComp_1$1",
+      3, "operator", "**", "MaybeComp_1$2",
+      3, "meta", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?= *\=(?!\=))/, "MaybeComp_1$3",
+      0, "MaybeComp_1$2"
+    ],
+    "MaybeComp_1$1": [
+      1, "whitespace", "MaybeComp_1$4"
+    ],
+    "MaybeComp_1$2": [
+      1, "whitespace", "MaybeComp_1$5"
+    ],
+    "MaybeComp_1$3": [
+      1, "whitespace", "MaybeComp_1$6"
+    ],
+    "MaybeComp_1$4": [
+      1, "ExprSuffix", "MaybeComp_1$7",
+      0, "MaybeComp_1$8"
+    ],
+    "MaybeComp_1$5": [
+      1, "ExprNoComma", "MaybeComp_1$8"
+    ],
+    "MaybeComp_1$6": [
+      "=", "MaybeComp_1$2"
+    ],
+    "MaybeComp_1$7": [
+      1, "whitespace", "MaybeComp_1$4"
+    ],
+    "MaybeComp_1$8": [
+      1, "whitespace", "MaybeComp_1$9"
+    ],
+    "MaybeComp_1$9": [
+      ",", "MaybeComp_1$10",
+      1, "CompFor", -1,
+      0, -1
+    ],
+    "MaybeComp_1$10": [
+      1, "whitespace", "MaybeComp_1$11"
+    ],
+    "MaybeComp_1$11": [
+      1, "CommaSep", -1,
+      0, -1
+    ],
+    "ParenPattern": [
+      "(", "ParenPattern$1"
+    ],
+    "ParenPattern$1": [
+      1, "whitespace", "ParenPattern$2"
+    ],
+    "ParenPattern$2": [
+      1, "Pattern", "ParenPattern$3"
+    ],
+    "ParenPattern$3": [
+      1, "whitespace", "ParenPattern$4"
+    ],
+    "ParenPattern$4": [
+      ")", -1
+    ],
+    "BracketPattern": [
+      "[", "BracketPattern$1"
+    ],
+    "BracketPattern$1": [
+      1, "whitespace", "BracketPattern$2"
+    ],
+    "BracketPattern$2": [
+      1, "Pattern", "BracketPattern$3"
+    ],
+    "BracketPattern$3": [
+      1, "whitespace", "BracketPattern$4"
+    ],
+    "BracketPattern$4": [
+      "]", -1
+    ],
+    "ParamList": [
+      "(", "ParamList$1"
+    ],
+    "ParamList$1": [
+      1, "whitespace", "ParamList$2"
+    ],
+    "ParamList$2": [
+      1, "CommaSep_11", "ParamList$3",
+      0, "ParamList$3"
+    ],
+    "ParamList$3": [
+      1, "whitespace", "ParamList$4"
+    ],
+    "ParamList$4": [
+      ")", -1
+    ],
+    "CommaSep_1": [
+      [6, "_lookahead_1"], "CommaSep_1$1",
+      2, "ParenPattern", "CommaSep_1$2", {"name":"ParenPattern"},
+      2, "BracketPattern", "CommaSep_1$2", {"name":"BracketPattern"}
+    ],
+    "CommaSep_1$1": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_1$2"
+    ],
+    "CommaSep_1$2": [
+      1, "whitespace", "CommaSep_1$3"
+    ],
+    "CommaSep_1$3": [
+      ",", "CommaSep_1$4",
+      0, -1
+    ],
+    "CommaSep_1$4": [
+      1, "whitespace", "CommaSep_1$5"
+    ],
+    "CommaSep_1$5": [
+      [6, "_lookahead_1"], "CommaSep_1$6",
+      2, "ParenPattern", "CommaSep_1$7", {"name":"ParenPattern"},
+      2, "BracketPattern", "CommaSep_1$7", {"name":"BracketPattern"},
+      0, "CommaSep_1$7"
+    ],
+    "CommaSep_1$6": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_1$7"
+    ],
+    "CommaSep_1$7": [
+      1, "whitespace", "CommaSep_1$3"
+    ],
+    "ParenExpr": [
+      "(", "ParenExpr$1"
+    ],
+    "ParenExpr$1": [
+      1, "whitespace", "ParenExpr$2"
+    ],
+    "ParenExpr$2": [
+      1, "MaybeComp", "ParenExpr$3",
+      0, "ParenExpr$3"
+    ],
+    "ParenExpr$3": [
+      1, "whitespace", "ParenExpr$4"
+    ],
+    "ParenExpr$4": [
+      ")", -1
+    ],
+    "ArrayLiteral": [
+      "[", "ArrayLiteral$1"
+    ],
+    "ArrayLiteral$1": [
+      1, "whitespace", "ArrayLiteral$2"
+    ],
+    "ArrayLiteral$2": [
+      1, "MaybeComp", "ArrayLiteral$3",
+      0, "ArrayLiteral$3"
+    ],
+    "ArrayLiteral$3": [
+      1, "whitespace", "ArrayLiteral$4"
+    ],
+    "ArrayLiteral$4": [
+      "]", -1
+    ],
+    "ObjectLiteral": [
+      "{", "ObjectLiteral$1"
+    ],
+    "ObjectLiteral$1": [
+      1, "whitespace", "ObjectLiteral$2"
+    ],
+    "ObjectLiteral$2": [
+      1, "CommaSep_4", "ObjectLiteral$3",
+      0, "ObjectLiteral$5"
+    ],
+    "ObjectLiteral$3": [
+      1, "whitespace", "ObjectLiteral$4"
+    ],
+    "ObjectLiteral$4": [
+      1, "CompFor", "ObjectLiteral$5",
+      0, "ObjectLiteral$5"
+    ],
+    "ObjectLiteral$5": [
+      1, "whitespace", "ObjectLiteral$6"
+    ],
+    "ObjectLiteral$6": [
+      "}", -1
+    ],
+    "LambdaDef": [
+      1, "CommaSep_5", "LambdaDef$1",
+      0, "LambdaDef$1"
+    ],
+    "LambdaDef$1": [
+      1, "whitespace", "LambdaDef$2"
+    ],
+    "LambdaDef$2": [
+      ":", "LambdaDef$3"
+    ],
+    "LambdaDef$3": [
+      1, "whitespace", "LambdaDef$4"
+    ],
+    "LambdaDef$4": [
+      1, "ExprNoComma", -1
+    ],
+    "Subscript": [
+      "[", "Subscript$1"
+    ],
+    "Subscript$1": [
+      1, "whitespace", "Subscript$2"
+    ],
+    "Subscript$2": [
+      1, "CommaSep_2", "Subscript$3"
+    ],
+    "Subscript$3": [
+      1, "whitespace", "Subscript$4"
+    ],
+    "Subscript$4": [
+      "]", -1
+    ],
+    "ExprSuffix": [
+      3, "operator", /^(?:(?:\^|\&|\||\<\<|\>\>|\+|\-|\*\*?|\@|\/|\%|\/)\=?|\=|\<|\>|\=\=|\>\=|\<\=|\<\>|\!\=|\:\=)/, "ExprSuffix$1",
+      3, "keyword", /^(?:or|and|in|is(?: +not)?|not(?: +in)?)(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix$1",
+      2, "ArgList", -1, {"name":"ArgList"},
+      2, "Subscript", -1, {"name":"Subscript"},
+      ".", "ExprSuffix$3",
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix$5"
+    ],
+    "ExprSuffix$1": [
+      1, "whitespace", "ExprSuffix$2"
+    ],
+    "ExprSuffix$2": [
+      1, "ExprNoComma", -1
+    ],
+    "ExprSuffix$3": [
+      1, "whitespace", "ExprSuffix$4"
+    ],
+    "ExprSuffix$4": [
+      3, "property callee", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?=\()/, -1,
+      3, "property", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, -1
+    ],
+    "ExprSuffix$5": [
+      1, "whitespace", "ExprSuffix$6"
+    ],
+    "ExprSuffix$6": [
+      1, "ExprNoComma", "ExprSuffix$7"
+    ],
+    "ExprSuffix$7": [
+      1, "whitespace", "ExprSuffix$8"
+    ],
+    "ExprSuffix$8": [
+      3, "keyword", /^else(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix$9",
+      0, -1
+    ],
+    "ExprSuffix$9": [
+      1, "whitespace", "ExprSuffix$10"
+    ],
+    "ExprSuffix$10": [
+      1, "ExprNoComma", -1
+    ],
+    "_lookahead_5": [
+      3, "keyword", /^(?:return|pass)(?![a-zA-Z¡-￿_0-9_])/, -1
+    ],
+    "ExprSuffix_1": [
+      3, "operator", /^(?:(?:\^|\&|\||\<\<|\>\>|\+|\-|\*\*?|\@|\/|\%|\/)\=?|\=|\<|\>|\=\=|\>\=|\<\=|\<\>|\!\=|\:\=)/, "ExprSuffix_1$1",
+      3, "keyword", /^(?:or|and|in|is(?: +not)?|not(?: +in)?)(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_1$1",
+      2, "ArgList", -1, {"name":"ArgList"},
+      2, "Subscript", -1, {"name":"Subscript"},
+      ".", "ExprSuffix_1$3",
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_1$5"
+    ],
+    "ExprSuffix_1$1": [
+      1, "whitespace", "ExprSuffix_1$2"
+    ],
+    "ExprSuffix_1$2": [
+      1, "ExprNoIn", -1
+    ],
+    "ExprSuffix_1$3": [
+      1, "whitespace", "ExprSuffix_1$4"
+    ],
+    "ExprSuffix_1$4": [
+      3, "property callee", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?=\()/, -1,
+      3, "property", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, -1
+    ],
+    "ExprSuffix_1$5": [
+      1, "whitespace", "ExprSuffix_1$6"
+    ],
+    "ExprSuffix_1$6": [
+      1, "ExprNoIn", "ExprSuffix_1$7"
+    ],
+    "ExprSuffix_1$7": [
+      1, "whitespace", "ExprSuffix_1$8"
+    ],
+    "ExprSuffix_1$8": [
+      3, "keyword", /^else(?![a-zA-Z¡-￿_0-9_])/, "ExprSuffix_1$9",
+      0, -1
+    ],
+    "ExprSuffix_1$9": [
+      1, "whitespace", "ExprSuffix_1$10"
+    ],
+    "ExprSuffix_1$10": [
+      1, "ExprNoIn", -1
+    ],
+    "CompFor": [
+      3, "keyword", /^async(?![a-zA-Z¡-￿_0-9_])/, "CompFor$1",
+      0, "CompFor$1"
+    ],
+    "CompFor$1": [
+      1, "whitespace", "CompFor$2"
+    ],
+    "CompFor$2": [
+      3, "keyword", /^for(?![a-zA-Z¡-￿_0-9_])/, "CompFor$3"
+    ],
+    "CompFor$3": [
+      1, "whitespace", "CompFor$4"
+    ],
+    "CompFor$4": [
+      [5, "_lookahead_2"], "CompFor$5",
+      1, "ExprNoIn", "CompFor$6"
+    ],
+    "CompFor$5": [
+      1, "Pattern", "CompFor$6"
+    ],
+    "CompFor$6": [
+      1, "whitespace", "CompFor$7"
+    ],
+    "CompFor$7": [
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, "CompFor$8"
+    ],
+    "CompFor$8": [
+      1, "whitespace", "CompFor$9"
+    ],
+    "CompFor$9": [
+      1, "Expr", "CompFor$10"
+    ],
+    "CompFor$10": [
+      1, "whitespace", "CompFor$11"
+    ],
+    "CompFor$11": [
+      1, "CompFor", -1,
+      1, "CompIf", -1,
+      0, -1
+    ],
+    "CommaSep": [
+      3, "operator", "**", "CommaSep$1",
+      3, "meta", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?= *\=(?!\=))/, "CommaSep$2",
+      0, "CommaSep$1"
+    ],
+    "CommaSep$1": [
+      1, "whitespace", "CommaSep$3"
+    ],
+    "CommaSep$2": [
+      1, "whitespace", "CommaSep$4"
+    ],
+    "CommaSep$3": [
+      1, "ExprNoComma", "CommaSep$5"
+    ],
+    "CommaSep$4": [
+      "=", "CommaSep$1"
+    ],
+    "CommaSep$5": [
+      1, "whitespace", "CommaSep$6"
+    ],
+    "CommaSep$6": [
+      ",", "CommaSep$7",
+      0, -1
+    ],
+    "CommaSep$7": [
+      1, "whitespace", "CommaSep$8"
+    ],
+    "CommaSep$8": [
+      3, "operator", "**", "CommaSep$9",
+      3, "meta", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*(?= *\=(?!\=))/, "CommaSep$10",
+      0, "CommaSep$9",
+      0, "CommaSep$11"
+    ],
+    "CommaSep$9": [
+      1, "whitespace", "CommaSep$12"
+    ],
+    "CommaSep$10": [
+      1, "whitespace", "CommaSep$13"
+    ],
+    "CommaSep$11": [
+      1, "whitespace", "CommaSep$6"
+    ],
+    "CommaSep$12": [
+      1, "ExprNoComma", "CommaSep$11"
+    ],
+    "CommaSep$13": [
+      "=", "CommaSep$9"
+    ],
+    "CommaSep_11": [
+      2, "op_10", "CommaSep_11$1", {"name":"op","token":"operator"},
+      0, "CommaSep_11$1"
+    ],
+    "CommaSep_11$1": [
+      1, "whitespace", "CommaSep_11$2"
+    ],
+    "CommaSep_11$2": [
+      3, "atom", /^self(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_11$3",
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_11$3"
+    ],
+    "CommaSep_11$3": [
+      1, "whitespace", "CommaSep_11$4"
+    ],
+    "CommaSep_11$4": [
+      ":", "CommaSep_11$5",
+      0, "CommaSep_11$6"
+    ],
+    "CommaSep_11$5": [
+      1, "whitespace", "CommaSep_11$7"
+    ],
+    "CommaSep_11$6": [
+      1, "whitespace", "CommaSep_11$8"
+    ],
+    "CommaSep_11$7": [
+      1, "ExprNoComma", "CommaSep_11$6"
+    ],
+    "CommaSep_11$8": [
+      3, "operator", "=", "CommaSep_11$9",
+      0, "CommaSep_11$11"
+    ],
+    "CommaSep_11$9": [
+      1, "whitespace", "CommaSep_11$10"
+    ],
+    "CommaSep_11$10": [
+      1, "ExprNoComma", "CommaSep_11$11"
+    ],
+    "CommaSep_11$11": [
+      1, "whitespace", "CommaSep_11$12"
+    ],
+    "CommaSep_11$12": [
+      ",", "CommaSep_11$13",
+      0, -1
+    ],
+    "CommaSep_11$13": [
+      1, "whitespace", "CommaSep_11$14"
+    ],
+    "CommaSep_11$14": [
+      2, "op_10", "CommaSep_11$15", {"name":"op","token":"operator"},
+      0, "CommaSep_11$15",
+      0, "CommaSep_11$16"
+    ],
+    "CommaSep_11$15": [
+      1, "whitespace", "CommaSep_11$17"
+    ],
+    "CommaSep_11$16": [
+      1, "whitespace", "CommaSep_11$12"
+    ],
+    "CommaSep_11$17": [
+      3, "atom", /^self(?![a-zA-Z¡-￿_0-9_])/, "CommaSep_11$18",
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_11$18"
+    ],
+    "CommaSep_11$18": [
+      1, "whitespace", "CommaSep_11$19"
+    ],
+    "CommaSep_11$19": [
+      ":", "CommaSep_11$20",
+      0, "CommaSep_11$21"
+    ],
+    "CommaSep_11$20": [
+      1, "whitespace", "CommaSep_11$22"
+    ],
+    "CommaSep_11$21": [
+      1, "whitespace", "CommaSep_11$23"
+    ],
+    "CommaSep_11$22": [
+      1, "ExprNoComma", "CommaSep_11$21"
+    ],
+    "CommaSep_11$23": [
+      3, "operator", "=", "CommaSep_11$24",
+      0, "CommaSep_11$16"
+    ],
+    "CommaSep_11$24": [
+      1, "whitespace", "CommaSep_11$25"
+    ],
+    "CommaSep_11$25": [
+      1, "ExprNoComma", "CommaSep_11$16"
+    ],
+    "_lookahead_1": [
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, -1
+    ],
+    "MaybeComp": [
+      3, "variable-2", [0, /^[a-zA-Z¡-￿__]/, /^[a-zA-Z¡-￿_0-9_]*/, [7, "isCompLocal"]], "MaybeComp$1",
+      1, "ExprNoComma", "MaybeComp$4"
+    ],
+    "MaybeComp$1": [
+      1, "whitespace", "MaybeComp$2"
+    ],
+    "MaybeComp$2": [
+      1, "ExprSuffix", "MaybeComp$3",
+      0, "MaybeComp$4"
+    ],
+    "MaybeComp$3": [
+      1, "whitespace", "MaybeComp$2"
+    ],
+    "MaybeComp$4": [
+      1, "whitespace", "MaybeComp$5"
+    ],
+    "MaybeComp$5": [
+      ",", "MaybeComp$6",
+      1, "CompFor", -1,
+      0, -1
+    ],
+    "MaybeComp$6": [
+      1, "whitespace", "MaybeComp$7"
+    ],
+    "MaybeComp$7": [
+      1, "CommaSep_3", -1,
+      0, -1
+    ],
+    "CommaSep_4": [
+      2, "DictProp", "CommaSep_4$1", {"name":"DictProp"}
+    ],
+    "CommaSep_4$1": [
+      1, "whitespace", "CommaSep_4$2"
+    ],
+    "CommaSep_4$2": [
+      ",", "CommaSep_4$3",
+      0, -1
+    ],
+    "CommaSep_4$3": [
+      1, "whitespace", "CommaSep_4$4"
+    ],
+    "CommaSep_4$4": [
+      2, "DictProp", "CommaSep_4$5", {"name":"DictProp"},
+      0, "CommaSep_4$5"
+    ],
+    "CommaSep_4$5": [
+      1, "whitespace", "CommaSep_4$2"
+    ],
+    "CommaSep_5": [
+      3, "operator", /^(?:\*|\*\*)/, "CommaSep_5$1",
+      0, "CommaSep_5$1"
+    ],
+    "CommaSep_5$1": [
+      1, "whitespace", "CommaSep_5$2"
+    ],
+    "CommaSep_5$2": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_5$3"
+    ],
+    "CommaSep_5$3": [
+      1, "whitespace", "CommaSep_5$4"
+    ],
+    "CommaSep_5$4": [
+      3, "operator", "=", "CommaSep_5$5",
+      0, "CommaSep_5$7"
+    ],
+    "CommaSep_5$5": [
+      1, "whitespace", "CommaSep_5$6"
+    ],
+    "CommaSep_5$6": [
+      1, "ExprNoComma", "CommaSep_5$7"
+    ],
+    "CommaSep_5$7": [
+      1, "whitespace", "CommaSep_5$8"
+    ],
+    "CommaSep_5$8": [
+      ",", "CommaSep_5$9",
+      0, -1
+    ],
+    "CommaSep_5$9": [
+      1, "whitespace", "CommaSep_5$10"
+    ],
+    "CommaSep_5$10": [
+      3, "operator", /^(?:\*|\*\*)/, "CommaSep_5$11",
+      0, "CommaSep_5$11",
+      0, "CommaSep_5$12"
+    ],
+    "CommaSep_5$11": [
+      1, "whitespace", "CommaSep_5$13"
+    ],
+    "CommaSep_5$12": [
+      1, "whitespace", "CommaSep_5$8"
+    ],
+    "CommaSep_5$13": [
+      3, "def", /^[a-zA-Z¡-￿__][a-zA-Z¡-￿_0-9_]*/, "CommaSep_5$14"
+    ],
+    "CommaSep_5$14": [
+      1, "whitespace", "CommaSep_5$15"
+    ],
+    "CommaSep_5$15": [
+      3, "operator", "=", "CommaSep_5$16",
+      0, "CommaSep_5$12"
+    ],
+    "CommaSep_5$16": [
+      1, "whitespace", "CommaSep_5$17"
+    ],
+    "CommaSep_5$17": [
+      1, "ExprNoComma", "CommaSep_5$12"
+    ],
+    "CommaSep_2": [
+      1, "ExprNoComma", "CommaSep_2$1",
+      ":", "CommaSep_2$2"
+    ],
+    "CommaSep_2$1": [
+      1, "whitespace", "CommaSep_2$3"
+    ],
+    "CommaSep_2$2": [
+      1, "whitespace", "CommaSep_2$4"
+    ],
+    "CommaSep_2$3": [
+      ":", "CommaSep_2$5",
+      0, "CommaSep_2$15"
+    ],
+    "CommaSep_2$4": [
+      1, "ExprNoComma", "CommaSep_2$6",
+      0, "CommaSep_2$6"
+    ],
+    "CommaSep_2$5": [
+      1, "whitespace", "CommaSep_2$7"
+    ],
+    "CommaSep_2$6": [
+      1, "whitespace", "CommaSep_2$8"
+    ],
+    "CommaSep_2$7": [
+      1, "ExprNoComma", "CommaSep_2$9",
+      0, "CommaSep_2$9"
+    ],
+    "CommaSep_2$8": [
+      ":", "CommaSep_2$10",
+      0, "CommaSep_2$15"
+    ],
+    "CommaSep_2$9": [
+      1, "whitespace", "CommaSep_2$11"
+    ],
+    "CommaSep_2$10": [
+      1, "whitespace", "CommaSep_2$12"
+    ],
+    "CommaSep_2$11": [
+      ":", "CommaSep_2$13",
+      0, "CommaSep_2$15"
+    ],
+    "CommaSep_2$12": [
+      1, "ExprNoComma", "CommaSep_2$15",
+      0, "CommaSep_2$15"
+    ],
+    "CommaSep_2$13": [
+      1, "whitespace", "CommaSep_2$14"
+    ],
+    "CommaSep_2$14": [
+      1, "ExprNoComma", "CommaSep_2$15",
+      0, "CommaSep_2$15"
+    ],
+    "CommaSep_2$15": [
+      1, "whitespace", "CommaSep_2$16"
+    ],
+    "CommaSep_2$16": [
+      ",", "CommaSep_2$17",
+      0, -1
+    ],
+    "CommaSep_2$17": [
+      1, "whitespace", "CommaSep_2$18"
+    ],
+    "CommaSep_2$18": [
+      1, "ExprNoComma", "CommaSep_2$19",
+      ":", "CommaSep_2$20",
+      0, "CommaSep_2$21"
+    ],
+    "CommaSep_2$19": [
+      1, "whitespace", "CommaSep_2$22"
+    ],
+    "CommaSep_2$20": [
+      1, "whitespace", "CommaSep_2$23"
+    ],
+    "CommaSep_2$21": [
+      1, "whitespace", "CommaSep_2$16"
+    ],
+    "CommaSep_2$22": [
+      ":", "CommaSep_2$24",
+      0, "CommaSep_2$21"
+    ],
+    "CommaSep_2$23": [
+      1, "ExprNoComma", "CommaSep_2$25",
+      0, "CommaSep_2$25"
+    ],
+    "CommaSep_2$24": [
+      1, "whitespace", "CommaSep_2$26"
+    ],
+    "CommaSep_2$25": [
+      1, "whitespace", "CommaSep_2$27"
+    ],
+    "CommaSep_2$26": [
+      1, "ExprNoComma", "CommaSep_2$28",
+      0, "CommaSep_2$28"
+    ],
+    "CommaSep_2$27": [
+      ":", "CommaSep_2$29",
+      0, "CommaSep_2$21"
+    ],
+    "CommaSep_2$28": [
+      1, "whitespace", "CommaSep_2$30"
+    ],
+    "CommaSep_2$29": [
+      1, "whitespace", "CommaSep_2$31"
+    ],
+    "CommaSep_2$30": [
+      ":", "CommaSep_2$32",
+      0, "CommaSep_2$21"
+    ],
+    "CommaSep_2$31": [
+      1, "ExprNoComma", "CommaSep_2$21",
+      0, "CommaSep_2$21"
+    ],
+    "CommaSep_2$32": [
+      1, "whitespace", "CommaSep_2$33"
+    ],
+    "CommaSep_2$33": [
+      1, "ExprNoComma", "CommaSep_2$21",
+      0, "CommaSep_2$21"
+    ],
+    "_lookahead_2": [
+      1, "Pattern", "_lookahead_2$1"
+    ],
+    "_lookahead_2$1": [
+      1, "whitespace", "_lookahead_2$2"
+    ],
+    "_lookahead_2$2": [
+      "\n", "_lookahead_2$3",
+      3, "keyword", /^in(?![a-zA-Z¡-￿_0-9_])/, -1
+    ],
+    "_lookahead_2$3": [
+      1, "whitespace", "_lookahead_2$2"
+    ],
+    "CompIf": [
+      3, "keyword", /^if(?![a-zA-Z¡-￿_0-9_])/, "CompIf$1"
+    ],
+    "CompIf$1": [
+      1, "whitespace", "CompIf$2"
+    ],
+    "CompIf$2": [
+      1, "Expr", "CompIf$3"
+    ],
+    "CompIf$3": [
+      1, "whitespace", "CompIf$4"
+    ],
+    "CompIf$4": [
+      1, "CompFor", -1,
+      1, "CompIf", -1,
+      0, -1
+    ],
+    "op_10": [
+      "*", "op_10$1"
+    ],
+    "op_10$1": [
+      1, "whitespace", "op_10$2"
+    ],
+    "op_10$2": [
+      /^\*?/, -1
+    ],
+    "CommaSep_3": [
+      1, "ExprNoComma", "CommaSep_3$1"
+    ],
+    "CommaSep_3$1": [
+      1, "whitespace", "CommaSep_3$2"
+    ],
+    "CommaSep_3$2": [
+      ",", "CommaSep_3$3",
+      0, -1
+    ],
+    "CommaSep_3$3": [
+      1, "whitespace", "CommaSep_3$4"
+    ],
+    "CommaSep_3$4": [
+      1, "ExprNoComma", "CommaSep_3$5",
+      0, "CommaSep_3$5"
+    ],
+    "CommaSep_3$5": [
+      1, "whitespace", "CommaSep_3$2"
+    ],
+    "DictProp": [
+      3, "operator", "**", "DictProp$1",
+      1, "ExprNoComma", "DictProp$3"
+    ],
+    "DictProp$1": [
+      1, "whitespace", "DictProp$2"
+    ],
+    "DictProp$2": [
+      1, "ExprNoComma", -1
+    ],
+    "DictProp$3": [
+      1, "whitespace", "DictProp$4"
+    ],
+    "DictProp$4": [
+      ":", "DictProp$5",
+      0, -1
+    ],
+    "DictProp$5": [
+      1, "whitespace", "DictProp$6"
+    ],
+    "DictProp$6": [
+      1, "ExprNoComma", -1
+    ]
+  };
+  var start = "_start";
+  var token = "_token";
 
   var grammar = /*#__PURE__*/Object.freeze({
     __proto__: null,
@@ -853,6 +1875,7 @@
   var allowNewline = ["ArgList", "ParamList", "FromImportList", "ParenExpr", "ArrayLiteral", "ObjectLiteral", "Subscript", "DictProp", "ParenPattern", "BracketPattern"];
 
   function maySkipNewline(_line, _pos, cx) {
+          console.log(cx && cx.name, _line, _pos);
     return cx && allowNewline.indexOf(cx.name) > -1
   }
 
@@ -953,4 +1976,4 @@
 
   CodeMirror__namespace.defineMode("google-python", function (conf) { return new PythonMode(conf); });
 
-})));
+}));

--- a/src/python.grammar
+++ b/src/python.grammar
@@ -89,7 +89,7 @@ skip whitespace {
   context FuncDef { ParamList ("->" Expr)? ":" Body }
 
   MaybeComp(E) { (compLocalName ExprSuffix(ExprNoComma)* | E) ("," CommaSep(E)? | CompFor)? }
-  CompFor { async? for (MaybePattern(in) | ExprNoIn) in Expr (CompFor | CompIf)? }
+  CompFor { async? for (MaybePattern("\n"* in) | ExprNoIn) in Expr (CompFor | CompIf)? }
   CompIf { if Expr (CompFor | CompIf)? }
 
   context ParenExpr { "(" MaybeComp(ExprNoComma)? ")" }


### PR DESCRIPTION
This is not the most elegant fix, but it seems to work.

I would love to understand why the MaybePattern(in) lookahead fails in
the presence of a EOL. I suspect that somehow maybeSkipNewLine works
differently during lookahead (is the context right?), but I'm not sure
how to go about verifying that.